### PR TITLE
fix: Unable to use Toast UI via npm import (fix #61)

### DIFF
--- a/src/js/component/cropper.js
+++ b/src/js/component/cropper.js
@@ -2,7 +2,7 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhnent.com>
  * @fileoverview Image crop module (start cropping, end cropping)
  */
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 import Component from '../interface/component';
 import Cropzone from '../extension/cropzone';
 import {keyCodes, componentNames} from '../consts';

--- a/src/js/component/filter.js
+++ b/src/js/component/filter.js
@@ -4,7 +4,7 @@
  */
 import {isUndefined, extend, forEach, filter} from 'tui-code-snippet';
 import Promise from 'core-js/library/es6/promise';
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 import Component from '../interface/component';
 import Mask from '../extension/mask';
 import consts from '../consts';

--- a/src/js/component/freeDrawing.js
+++ b/src/js/component/freeDrawing.js
@@ -2,7 +2,7 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhnent.com>
  * @fileoverview Free drawing module, Set brush
  */
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 import Component from '../interface/component';
 import consts from '../consts';
 

--- a/src/js/component/icon.js
+++ b/src/js/component/icon.js
@@ -2,7 +2,7 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhnent.com>
  * @fileoverview Add icon module
  */
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 import snippet from 'tui-code-snippet';
 import Promise from 'core-js/library/es6/promise';
 import Component from '../interface/component';

--- a/src/js/component/line.js
+++ b/src/js/component/line.js
@@ -2,7 +2,7 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhnent.com>
  * @fileoverview Free drawing module, Set brush
  */
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 import Component from '../interface/component';
 import consts from '../consts';
 

--- a/src/js/component/rotation.js
+++ b/src/js/component/rotation.js
@@ -2,7 +2,7 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhnent.com>
  * @fileoverview Image rotation module
  */
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 import Promise from 'core-js/library/es6/promise';
 import Component from '../interface/component';
 import consts from '../consts';

--- a/src/js/component/shape.js
+++ b/src/js/component/shape.js
@@ -2,7 +2,7 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhnent.com>
  * @fileoverview Shape component
  */
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 import Promise from 'core-js/library/es6/promise';
 import Component from '../interface/component';
 import consts from '../consts';

--- a/src/js/component/text.js
+++ b/src/js/component/text.js
@@ -2,7 +2,7 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhnent.com>
  * @fileoverview Text module
  */
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 import snippet from 'tui-code-snippet';
 import Promise from 'core-js/library/es6/promise';
 import Component from '../interface/component';

--- a/src/js/extension/blur.js
+++ b/src/js/extension/blur.js
@@ -2,7 +2,7 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhnent.com>
  * @fileoverview Blur extending fabric.Image.filters.Convolute
  */
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 
 /**
  * Blur object

--- a/src/js/extension/colorFilter.js
+++ b/src/js/extension/colorFilter.js
@@ -2,7 +2,7 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhnent.com>
  * @fileoverview ColorFilter extending fabric.Image.filters.BaseFilter
  */
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 
 /**
  * ColorFilter object

--- a/src/js/extension/cropzone.js
+++ b/src/js/extension/cropzone.js
@@ -3,7 +3,7 @@
  * @fileoverview Cropzone extending fabric.Rect
  */
 import snippet from 'tui-code-snippet';
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 import {clamp} from '../util';
 
 const CORNER_TYPE_TOP_LEFT = 'tl';

--- a/src/js/extension/emboss.js
+++ b/src/js/extension/emboss.js
@@ -2,7 +2,7 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhnent.com>
  * @fileoverview Emboss extending fabric.Image.filters.Convolute
  */
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 
 /**
  * Emboss object

--- a/src/js/extension/mask.js
+++ b/src/js/extension/mask.js
@@ -2,7 +2,7 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhnent.com>
  * @fileoverview Mask extending fabric.Image.filters.Mask
  */
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 
 /**
  * Mask object

--- a/src/js/extension/sharpen.js
+++ b/src/js/extension/sharpen.js
@@ -2,7 +2,7 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhnent.com>
  * @fileoverview Sharpen extending fabric.Image.filters.Convolute
  */
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 
 /**
  * Sharpen object

--- a/src/js/graphics.js
+++ b/src/js/graphics.js
@@ -4,7 +4,7 @@
  */
 import snippet from 'tui-code-snippet';
 import Promise from 'core-js/library/es6/promise';
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 import ImageLoader from './component/imageLoader';
 import Cropper from './component/cropper';
 import Flip from './component/flip';

--- a/test/command.spec.js
+++ b/test/command.spec.js
@@ -4,7 +4,7 @@
  */
 import snippet from 'tui-code-snippet';
 import Promise from 'core-js/library/es6/promise';
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 import $ from 'jquery';
 import Invoker from '../src/js/invoker';
 import commandFactory from '../src/js/factory/command';

--- a/test/cropper.spec.js
+++ b/test/cropper.spec.js
@@ -3,7 +3,7 @@
  * @fileoverview Test cases of "src/js/component/cropper.js"
  */
 import snippet from 'tui-code-snippet';
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 import $ from 'jquery';
 import Cropper from '../src/js/component/cropper';
 import Graphics from '../src/js/graphics';

--- a/test/flip.spec.js
+++ b/test/flip.spec.js
@@ -2,7 +2,7 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhnent.com>
  * @fileoverview Test cases of "src/js/component/flip.js"
  */
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 import $ from 'jquery';
 import Graphics from '../src/js/graphics';
 import Flip from '../src/js/component/flip';

--- a/test/graphics.spec.js
+++ b/test/graphics.spec.js
@@ -3,7 +3,7 @@
  * @fileoverview Tests command with command-factory
  */
 import snippet from 'tui-code-snippet';
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 import $ from 'jquery';
 import Graphics from '../src/js/graphics';
 import consts from '../src/js/consts';

--- a/test/icon.spec.js
+++ b/test/icon.spec.js
@@ -2,7 +2,7 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhnent.com>
  * @fileoverview Test cases of "src/js/component/icon.js"
  */
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 import $ from 'jquery';
 import Graphics from '../src/js/graphics';
 import Icon from '../src/js/component/icon';

--- a/test/line.spec.js
+++ b/test/line.spec.js
@@ -2,7 +2,7 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhnent.com>
  * @fileoverview Test cases of "src/js/component/line.js"
  */
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 import $ from 'jquery';
 import Graphics from '../src/js/graphics';
 import Line from '../src/js/component/line';

--- a/test/rotation.spec.js
+++ b/test/rotation.spec.js
@@ -2,7 +2,7 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhnent.com>
  * @fileoverview Test cases of "src/js/component/rotation.js"
  */
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 import $ from 'jquery';
 import Graphics from '../src/js/graphics';
 import Rotation from '../src/js/component/rotation';

--- a/test/shape.spec.js
+++ b/test/shape.spec.js
@@ -2,7 +2,7 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhnent.com>
  * @fileoverview Test cases of "src/js/component/line.js"
  */
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 import $ from 'jquery';
 import Graphics from '../src/js/graphics';
 import Shape from '../src/js/component/shape';

--- a/test/text.spec.js
+++ b/test/text.spec.js
@@ -2,7 +2,7 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhnent.com>
  * @fileoverview Test cases of "src/js/component/text.js"
  */
-import fabric from 'fabric/dist/fabric.require';
+import {fabric} from 'fabric';
 import $ from 'jquery';
 import Graphics from '../src/js/graphics';
 import Text from '../src/js/component/text';


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
When Toast UI is included in the codebase via npm,
```
import ImageEditor from 'npm:tui-image-editor';
import CodeSnippet from 'npm:tui-code-snippet';
import ColorPicket from 'npm:tui-color-picker';
```
it gave me `_fabric2.default.util is undefined` error. This was due to how `fabric` library was being imported into the tui image editor.

This PR correctly imports `fabric` into tui-image-editor so that the clients using tui-image-editor can reliably use the library via npm.