### PR TITLE
fix: Remove title attribute for disable browser's default tooltip (fix: #187)

### DIFF
--- a/src/css/main.styl
+++ b/src/css/main.styl
@@ -128,7 +128,7 @@ body > textarea
             padding: 7px 8px 3px 8px;
             cursor: pointer;
             margin: 0 4px;
-        > .{prefix}-item[title]:hover
+        > .{prefix}-item[tooltip-content]:hover
             &:before
                 content: '';
                 position: absolute;
@@ -139,11 +139,10 @@ body > textarea
                 border-right: 7px solid transparent;
                 border-top: 7px solid #2f2f2f;
                 border-left: 7px solid transparent;
-                position: absolute;
                 left: 13px;
                 top: -2px;
             &:after
-                content: attr(title);
+                content: attr(tooltip-content);
                 position: absolute;
                 display: inline-block;
                 background-color: #2f2f2f;
@@ -153,7 +152,7 @@ body > textarea
                 font-weight: lighter;
                 border-radius: 3px;
                 max-height: 23px;
-                top: -22px;
+                top: -25px;
                 left: 0;
                 min-width: 24px;
         > .{prefix}-item.active

--- a/src/css/position.styl
+++ b/src/css/position.styl
@@ -2,7 +2,7 @@
 .{prefix}-container
   &.left
     .{prefix}-menu
-        > .{prefix}-item[title]
+        > .{prefix}-item[tooltip-content]
             &:before
                 left: 28px;
                 top: 11px;
@@ -11,7 +11,7 @@
                 border-bottom: 7px solid transparent;
             &:after
                 top: 7px;
-                left: 39px;
+                left: 42px;
                 white-space: nowrap;
     .{prefix}-submenu
         left: 0;
@@ -78,7 +78,7 @@
 .{prefix}-container
   &.right
     .{prefix}-menu
-        > .{prefix}-item[title]
+        > .{prefix}-item[tooltip-content]
             &:before
                 left: -3px;
                 top: 11px;
@@ -87,7 +87,8 @@
                 border-bottom: 7px solid transparent;
             &:after
                 top: 7px;
-                left: -44px;
+                left: unset;
+                right: 43px;
                 white-space: nowrap;
     .{prefix}-submenu
         right: 0;
@@ -131,7 +132,7 @@
     .{prefix}-main-container
         bottom: 0;
     .{prefix}-menu
-        > .{prefix}-item[title]
+        > .{prefix}-item[tooltip-content]
             &:before
                 left: 13px;
                 border-top: 0;

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -343,7 +343,7 @@ class Ui {
 
         btnElement.id = `tie-btn-${menuName}`;
         btnElement.className = 'tui-image-editor-item normal';
-        btnElement.title = this._locale.localize(menuName.replace(/^[a-z]/g, $0 => $0.toUpperCase()));
+        btnElement.setAttribute('tooltip-content', this._locale.localize(menuName.replace(/^[a-z]/g, $0 => $0.toUpperCase())));
         btnElement.innerHTML = menuItemHtml;
 
         this._menuElement.appendChild(btnElement);

--- a/src/js/ui/template/controls.js
+++ b/src/js/ui/template/controls.js
@@ -4,21 +4,21 @@ export default ({locale, biImage, iconStyle: {normal, hover, disabled}, loadButt
             <img src="${biImage}" />
         </div>
         <ul class="tui-image-editor-menu">
-            <li id="tie-btn-undo" class="tui-image-editor-item" title="${locale.localize('Undo')}">
+            <li id="tie-btn-undo" class="tui-image-editor-item">
                 <svg class="svg_ic-menu">
                     <use xlink:href="${normal.path}#${normal.name}-ic-undo" class="enabled"/>
                     <use xlink:href="${disabled.path}#${disabled.name}-ic-undo" class="normal"/>
                     <use xlink:href="${hover.path}#${hover.name}-ic-undo" class="hover"/>
                 </svg>
             </li>
-            <li id="tie-btn-redo" class="tui-image-editor-item" title="${locale.localize('Redo')}">
+            <li id="tie-btn-redo" class="tui-image-editor-item">
                 <svg class="svg_ic-menu">
                     <use xlink:href="${normal.path}#${normal.name}-ic-redo" class="enabled"/>
                     <use xlink:href="${disabled.path}#${disabled.name}-ic-redo" class="normal"/>
                     <use xlink:href="${hover.path}#${hover.name}-ic-redo" class="hover"/>
                 </svg>
             </li>
-            <li id="tie-btn-reset" class="tui-image-editor-item" title="${locale.localize('Reset')}">
+            <li id="tie-btn-reset" class="tui-image-editor-item">
                 <svg class="svg_ic-menu">
                     <use xlink:href="${normal.path}#${normal.name}-ic-reset" class="enabled"/>
                     <use xlink:href="${disabled.path}#${disabled.name}-ic-reset" class="normal"/>
@@ -28,14 +28,14 @@ export default ({locale, biImage, iconStyle: {normal, hover, disabled}, loadButt
             <li class="tui-image-editor-item">
                 <div class="tui-image-editor-icpartition"></div>
             </li>
-            <li id="tie-btn-delete" class="tui-image-editor-item" title="${locale.localize('Delete')}">
+            <li id="tie-btn-delete" class="tui-image-editor-item">
                 <svg class="svg_ic-menu">
                     <use xlink:href="${normal.path}#${normal.name}-ic-delete" class="enabled"/>
                     <use xlink:href="${disabled.path}#${disabled.name}-ic-delete" class="normal"/>
                     <use xlink:href="${hover.path}#${hover.name}-ic-delete" class="hover"/>
                 </svg>
             </li>
-            <li id="tie-btn-delete-all" class="tui-image-editor-item" title="${locale.localize('Delete-all')}">
+            <li id="tie-btn-delete-all" class="tui-image-editor-item">
                 <svg class="svg_ic-menu">
                     <use xlink:href="${normal.path}#${normal.name}-ic-delete-all" class="enabled"/>
                     <use xlink:href="${disabled.path}#${disabled.name}-ic-delete-all" class="normal"/>


### PR DESCRIPTION

<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

- Remove `title` attribute from menu buttons for disable browser's default tooltip.
ref: #187 

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨