### PR TITLE
Fix: Fix spelling of textDecoration and line-through

### DIFF
--- a/src/js/command/addText.js
+++ b/src/js/command/addText.js
@@ -24,7 +24,7 @@ const command = {
      *         @param {string} [options.styles.fontStyle] Type of inclination (normal / italic)
      *         @param {string} [options.styles.fontWeight] Type of thicker or thinner looking (normal / bold)
      *         @param {string} [options.styles.textAlign] Type of text align (left / center / right)
-     *         @param {string} [options.styles.textDecoraiton] Type of line (underline / line-throgh / overline)
+     *         @param {string} [options.styles.textDecoration] Type of line (underline / line-through / overline)
      *     @param {{x: number, y: number}} [options.position] - Initial position
      * @returns {Promise}
      */

--- a/src/js/command/changeTextStyle.js
+++ b/src/js/command/changeTextStyle.js
@@ -24,7 +24,7 @@ const command = {
      *     @param {string} [styles.fontStyle] Type of inclination (normal / italic)
      *     @param {string} [styles.fontWeight] Type of thicker or thinner looking (normal / bold)
      *     @param {string} [styles.textAlign] Type of text align (left / center / right)
-     *     @param {string} [styles.textDecoraiton] Type of line (underline / line-throgh / overline)
+     *     @param {string} [styles.textDecoration] Type of line (underline / line-through / overline)
      * @returns {Promise}
      */
     execute(graphics, id, styles) {

--- a/src/js/command/setObjectProperties.js
+++ b/src/js/command/setObjectProperties.js
@@ -23,7 +23,7 @@ const command = {
      *     @param {string} [props.fontStyle] Type of inclination (normal / italic)
      *     @param {string} [props.fontWeight] Type of thicker or thinner looking (normal / bold)
      *     @param {string} [props.textAlign] Type of text align (left / center / right)
-     *     @param {string} [props.textDecoraiton] Type of line (underline / line-throgh / overline)
+     *     @param {string} [props.textDecoration] Type of line (underline / line-through / overline)
      * @returns {Promise}
      */
     execute(graphics, id, props) {

--- a/src/js/component/text.js
+++ b/src/js/component/text.js
@@ -21,7 +21,8 @@ const resetStyles = {
     fontStyle: 'normal',
     fontWeight: 'normal',
     textAlign: 'left',
-    textDecoraiton: ''
+    textDecoration: '',
+    underline: false
 };
 const {browser} = snippet;
 
@@ -209,7 +210,7 @@ class Text extends Component {
      *         @param {string} [options.styles.fontStyle] Type of inclination (normal / italic)
      *         @param {string} [options.styles.fontWeight] Type of thicker or thinner looking (normal / bold)
      *         @param {string} [options.styles.textAlign] Type of text align (left / center / right)
-     *         @param {string} [options.styles.textDecoraiton] Type of line (underline / line-throgh / overline)
+     *         @param {string} [options.styles.textDecoration] Type of line (underline / line-through / overline)
      *     @param {{x: number, y: number}} [options.position] - Initial position
      * @returns {Promise}
      */
@@ -277,7 +278,7 @@ class Text extends Component {
      *     @param {string} [styleObj.fontStyle] Type of inclination (normal / italic)
      *     @param {string} [styleObj.fontWeight] Type of thicker or thinner looking (normal / bold)
      *     @param {string} [styleObj.textAlign] Type of text align (left / center / right)
-     *     @param {string} [styleObj.textDecoraiton] Type of line (underline / line-throgh / overline)
+     *     @param {string} [styleObj.textDecoration] Type of line (underline / line-through / overline)
      * @returns {Promise}
      */
     setStyle(activeObj, styleObj) {

--- a/src/js/graphics.js
+++ b/src/js/graphics.js
@@ -657,7 +657,7 @@ class Graphics {
      *     @param {string} [props.fontStyle] Type of inclination (normal / italic)
      *     @param {string} [props.fontWeight] Type of thicker or thinner looking (normal / bold)
      *     @param {string} [props.textAlign] Type of text align (left / center / right)
-     *     @param {string} [props.textDecoraiton] Type of line (underline / line-throgh / overline)
+     *     @param {string} [props.textDecoration] Type of line (underline / line-through / overline)
      * @returns {Object} applied properties
      */
     setObjectProperties(id, props) {

--- a/src/js/imageEditor.js
+++ b/src/js/imageEditor.js
@@ -207,7 +207,7 @@ class ImageEditor {
      * @property {string} fontStyle - Type of inclination (normal / italic)
      * @property {string} fontWeight - Type of thicker or thinner looking (normal / bold)
      * @property {string} textAlign - Type of text align (left / center / right)
-     * @property {string} textDecoraiton - Type of line (underline / line-throgh / overline)
+     * @property {string} textDecoration - Type of line (underline / line-through / overline)
      */
 
     /**
@@ -982,7 +982,7 @@ class ImageEditor {
      *         @param {string} [options.styles.fontStyle] Type of inclination (normal / italic)
      *         @param {string} [options.styles.fontWeight] Type of thicker or thinner looking (normal / bold)
      *         @param {string} [options.styles.textAlign] Type of text align (left / center / right)
-     *         @param {string} [options.styles.textDecoraiton] Type of line (underline / line-throgh / overline)
+     *         @param {string} [options.styles.textDecoration] Type of line (underline / line-through / overline)
      *     @param {{x: number, y: number}} [options.position] - Initial position
      * @returns {Promise}
      * @example
@@ -1033,7 +1033,7 @@ class ImageEditor {
      *     @param {string} [styleObj.fontStyle] Type of inclination (normal / italic)
      *     @param {string} [styleObj.fontWeight] Type of thicker or thinner looking (normal / bold)
      *     @param {string} [styleObj.textAlign] Type of text align (left / center / right)
-     *     @param {string} [styleObj.textDecoraiton] Type of line (underline / line-throgh / overline)
+     *     @param {string} [styleObj.textDecoration] Type of line (underline / line-through / overline)
      * @returns {Promise}
      * @example
      * imageEditor.changeTextStyle(id, {

--- a/src/js/ui/text.js
+++ b/src/js/ui/text.js
@@ -102,7 +102,10 @@ class Text extends Submenu {
         const styleObj = {
             'bold': {fontWeight: 'bold'},
             'italic': {fontStyle: 'italic'},
-            'underline': {textDecoration: 'underline'}
+            'underline': {
+                underline: true,
+                textDecoration: 'underline'
+            }
         }[styleType];
 
         this.effect[styleType] = !this.effect[styleType];


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [X] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [X] Docs have been added/updated (for bug fixes/features)
- [X] It does not introduce a breaking change or has description for the breaking change

### Description
Fix related to issue #221 and PR https://github.com/nhn/tui.image-editor/pull/225
Updates the documentation related to
textDecoration and line-through and 2 instances where they wrong key
was used in code configuration. 

close: resolves some documentation related to the bug but not the bug.
---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨