### PR TITLE
fix: white theme style bug

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for TOAST UI Image Editor v3.7.0
+// Type definitions for TOAST UI Image Editor v3.7.1
 // TypeScript Version: 3.2.2
 
 declare namespace tuiImageEditor {

--- a/src/css/position.styl
+++ b/src/css/position.styl
@@ -142,7 +142,7 @@
                 top: 38px;
     .{prefix}-submenu
         top: 0;
-        bottom: inherit;
+        bottom: auto;
         > div
             padding-top: 24px;
             vertical-align: top;

--- a/src/js/ui/template/style.js
+++ b/src/js/ui/template/style.js
@@ -44,14 +44,15 @@ export default ({
     .tie-text-align-button.right .tui-image-editor-button.right label,
     .tie-mask-apply.apply.active .tui-image-editor-button.apply label,
     .tui-image-editor-container .tui-image-editor-submenu .tui-image-editor-button:hover > label,
-    .tui-image-editor-container .tui-image-editor-checkbox input + label {
+    .tui-image-editor-container .tui-image-editor-checkbox label > span {
         ${subMenuLabelActive}
     }
     .tui-image-editor-container .tui-image-editor-submenu .tui-image-editor-button > label,
-    .tui-image-editor-container .tui-image-editor-range-wrap.tui-image-editor-newline.short label {
+    .tui-image-editor-container .tui-image-editor-range-wrap.tui-image-editor-newline.short label,
+    .tui-image-editor-container .tui-image-editor-range-wrap.tui-image-editor-newline.short label > span {
         ${subMenuLabelNormal}
     }
-    .tui-image-editor-container .tui-image-editor-range-wrap label {
+    .tui-image-editor-container .tui-image-editor-range-wrap label > span {
         ${subMenuRangeTitle}
     }
     .tui-image-editor-container .tui-image-editor-partition > div {
@@ -61,10 +62,10 @@ export default ({
     .tui-image-editor-container.right .tui-image-editor-submenu .tui-image-editor-partition > div {
         ${submenuPartitionHorizontal}
     }
-    .tui-image-editor-container .tui-image-editor-checkbox input + label:before {
+    .tui-image-editor-container .tui-image-editor-checkbox label > span:before {
         ${submenuCheckbox}
     }
-    .tui-image-editor-container .tui-image-editor-checkbox input:checked + label:before {
+    .tui-image-editor-container .tui-image-editor-checkbox label > input:checked + span:before {
         border: 0;
     }
     .tui-image-editor-container .tui-image-editor-virtual-range-pointer {


### PR DESCRIPTION
* whiteTheme  스킨일경우 필터메뉴의 체크박스가 안보이는 버그 수정 (이전 멀티인스턴스 관련 css  수정의 사이드 이팩트)
* 서브메뉴 타이틀이 top일 경우 아래와 같이 메뉴가 편집영역을 덮어버리는 버그 수정
  * ![스크린샷 2019-12-10 오전 11 57 37](https://user-images.githubusercontent.com/35218826/70491308-4b1ae000-1b44-11ea-9650-e086377ae8f1.png)
