### PR TITLE
fix: fixed setCropzoneRect floating point bug (fix #114)

### DIFF
--- a/src/js/component/cropper.js
+++ b/src/js/component/cropper.js
@@ -7,7 +7,7 @@ import fabric from 'fabric';
 import Component from '../interface/component';
 import Cropzone from '../extension/cropzone';
 import {keyCodes, componentNames} from '../consts';
-import {clamp} from '../util';
+import {clamp, fixFloatingPoint} from '../util';
 
 const MOUSE_MOVE_THRESHOLD = 10;
 const DEFAULT_OPTION = {
@@ -328,7 +328,7 @@ class Cropper extends Component {
         [width, height] = snippet.map([width, height], sizeValue => sizeValue * scaleWidth);
 
         const scaleHeight = getScale(height, originalHeight);
-        [width, height] = snippet.map([width, height], sizeValue => sizeValue * scaleHeight);
+        [width, height] = snippet.map([width, height], sizeValue => fixFloatingPoint(sizeValue * scaleHeight));
 
         return {
             top: (originalHeight - height) / 2,

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -8,7 +8,6 @@ const {min, max} = Math;
 let hostnameSent = false;
 
 module.exports = {
-
     /**
      * Clamp value
      * @param {number} value - Value
@@ -188,6 +187,11 @@ module.exports = {
 
         return new Blob([uInt8Array], {type: mimeString});
     },
+    /**
+     * Fix floating point diff.
+     * @param {number} value - original value
+     * @returns {number} fixed value
+     */
     fixFloatingPoint(value) {
         return Number(value.toFixed(FLOATING_POINT_DIGIT));
     }

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -3,6 +3,7 @@
  * @fileoverview Util
  */
 import {forEach, sendHostname} from 'tui-code-snippet';
+const FLOATING_POINT_DIGIT = 2;
 const {min, max} = Math;
 let hostnameSent = false;
 
@@ -186,5 +187,8 @@ module.exports = {
         }
 
         return new Blob([uInt8Array], {type: mimeString});
+    },
+    fixFloatingPoint(value) {
+        return Number(value.toFixed(FLOATING_POINT_DIGIT));
     }
 };

--- a/test/cropper.spec.js
+++ b/test/cropper.spec.js
@@ -296,6 +296,16 @@ describe('Cropper', () => {
                 .toBe((16 / 9).toFixed(1));
         });
 
+        it('Even in situations with floating point problems, should calculate the exact width you expect.', () => {
+            spyOn(canvas, 'getWidth').and.returnValue(408);
+            spyOn(canvas, 'getHeight').and.returnValue(312);
+            spyOn(cropper._cropzone, 'set').and.callThrough();
+
+            cropper.setCropzoneRect(16 / 9);
+
+            expect(cropper._cropzone.set.calls.first().args[0].width).toBe(408);
+        });
+
         it('should remove cropzone of cropper when falsy is passed', () => {
             cropper.setCropzoneRect();
             expect(cropper.getCropzoneRect()).toBeFalsy();


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description
#### issue
* https://github.com/nhn/tui.image-editor/issues/114

* '408x312'이미지에 '16 : 9 '비율을 적용하면'getCropzoneRect () '메소드가 null을 반환합니다.

#### 원인
* 원본 이미지의 크기에 맞게 16 : 9 의 비율값을 이용하여 cropzone 크기 계산시 부동 소수점 계산 오차에 의해 width값에 +0.00000000003 의 오차가 생김
* (보통의 경우에 미세한 오차는 큰 상관이 없음 하지만 아래와 같은 경우에 문제가 생김)
* width값 오차로 인해 left 값 계산시 `left = (originalWidth - width) / 2` 또한 오차가 생기고 left가 마이너스 값이 되면서 캔버스 유효 범위를 벗어나게됨.

#### 해결
* 부동 소수점 오차를 해결하기 위해 width, height 최종 결과값에 소수점 2 번째 자리에서 반올림 하여 0.00000000003의 오차를 해결 (오차 해결방식은 fabricjs 코드를 참고함)
* width, height 값만 정확하면 그에 따른 left, top 값은 부동소수점 오차가 있어도 isValid 값에 영향을 받지 않게 되는 값을 갖게 되므로 문제가 없게됨
  
---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨