### PR TITLE
fix: change the way corner type information is obtained (fix #118)

### DIFF
--- a/src/js/extension/cropzone.js
+++ b/src/js/extension/cropzone.js
@@ -284,8 +284,9 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
      * @private
      */
     _onScaling(fEvent) {
+        const selectedCorner = fEvent.transform.corner;
         const pointer = this.canvas.getPointer(fEvent.e);
-        const settings = this._calcScalingSizeFromPointer(pointer);
+        const settings = this._calcScalingSizeFromPointer(pointer, selectedCorner);
 
         // On scaling cropzone,
         // change real width and height and fix scaleFactor to 1
@@ -295,10 +296,11 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
     /**
      * Calc scaled size from mouse pointer with selected corner
      * @param {{x: number, y: number}} pointer - Mouse position
+     * @param {string} selectedCorner - selected corner type
      * @returns {Object} Having left or(and) top or(and) width or(and) height.
      * @private
      */
-    _calcScalingSizeFromPointer(pointer) {
+    _calcScalingSizeFromPointer(pointer, selectedCorner) {
         const pointerX = pointer.x,
             pointerY = pointer.y,
             tlScalingSize = this._calcTopLeftScalingSizeFromPointer(pointerX, pointerY),
@@ -308,7 +310,7 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
          * @todo: 일반 객체에서 shift 조합키를 누르면 free size scaling이 됨 --> 확인해볼것
          *      canvas.class.js // _scaleObject: function(...){...}
          */
-        return this._makeScalingSettings(tlScalingSize, brScalingSize);
+        return this._makeScalingSettings(tlScalingSize, brScalingSize, selectedCorner);
     },
 
     /**
@@ -357,10 +359,11 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
      * Make scaling settings
      * @param {{width: number, height: number, left: number, top: number}} tl - Top-Left setting
      * @param {{width: number, height: number}} br - Bottom-Right setting
+     * @param {string} selectedCorner - selected corner type
      * @returns {{width: ?number, height: ?number, left: ?number, top: ?number}} Position setting
      * @private
      */
-    _makeScalingSettings(tl, br) {
+    _makeScalingSettings(tl, br, selectedCorner) {
         const tlWidth = tl.width;
         const tlHeight = tl.height;
         const brHeight = br.height;
@@ -369,7 +372,7 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
         const tlTop = tl.top;
         let settings;
 
-        switch (this.__corner) {
+        switch (selectedCorner) {
             case CORNER_TYPE_TOP_LEFT:
                 settings = tl;
                 break;

--- a/test/cropzone.spec.js
+++ b/test/cropzone.spec.js
@@ -176,70 +176,62 @@ describe('Cropzone', () => {
             };
         let expected, actual;
 
-        cropzone.__corner = 'tl';
         expected = {
             width: 1,
             height: 2,
             left: 3,
             top: 4
         };
-        actual = cropzone._makeScalingSettings(mockTL, mockBR);
+        actual = cropzone._makeScalingSettings(mockTL, mockBR, 'tl');
         expect(expected).toEqual(actual);
 
-        cropzone.__corner = 'tr';
         expected = {
             width: 5,
             height: 2,
             top: 4
         };
-        actual = cropzone._makeScalingSettings(mockTL, mockBR);
+        actual = cropzone._makeScalingSettings(mockTL, mockBR, 'tr');
         expect(expected).toEqual(actual);
 
-        cropzone.__corner = 'bl';
         expected = {
             width: 1,
             height: 6,
             left: 3
         };
-        actual = cropzone._makeScalingSettings(mockTL, mockBR);
+        actual = cropzone._makeScalingSettings(mockTL, mockBR, 'bl');
         expect(expected).toEqual(actual);
 
-        cropzone.__corner = 'br';
         expected = {
             width: 5,
             height: 6
         };
-        actual = cropzone._makeScalingSettings(mockTL, mockBR);
+        actual = cropzone._makeScalingSettings(mockTL, mockBR, 'br');
         expect(expected).toEqual(actual);
 
-        cropzone.__corner = 'ml';
         expected = {
             width: 1,
             left: 3
         };
-        actual = cropzone._makeScalingSettings(mockTL, mockBR);
+        actual = cropzone._makeScalingSettings(mockTL, mockBR, 'ml');
         expect(expected).toEqual(actual);
 
-        cropzone.__corner = 'mt';
         expected = {
             height: 2,
             top: 4
         };
-        actual = cropzone._makeScalingSettings(mockTL, mockBR);
+        actual = cropzone._makeScalingSettings(mockTL, mockBR, 'mt');
         expect(expected).toEqual(actual);
 
-        cropzone.__corner = 'mr';
         expected = {
             width: 5
         };
-        actual = cropzone._makeScalingSettings(mockTL, mockBR);
+        actual = cropzone._makeScalingSettings(mockTL, mockBR, 'mr');
         expect(expected).toEqual(actual);
 
-        cropzone.__corner = 'mb';
         expected = {
             height: 6
         };
-        actual = cropzone._makeScalingSettings(mockTL, mockBR);
+        actual = cropzone._makeScalingSettings(mockTL, mockBR, 'mb');
         expect(expected).toEqual(actual);
     });
 });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description
#### issue
* https://github.com/nhn/tui.image-editor/issues/118
* ![](https://user-images.githubusercontent.com/35218826/71879868-6c3a1500-3172-11ea-83dc-2042b22ecf1e.png)
* cropzone을 가장자리로 이동시킨후 크기조정을 하면 cropzone이 켄버스 영역 밖으로 벗어나버림

#### 원인
* Object 리사이즈를 위해 컨트롤을 선택할경우 각 방향의 8개의 컨트롤중 어느것을 선택하여 리사이즈 중인지 판별하기 위하여 `Object.__corner` 값을 이용하여 판별함
* 리사이즈중 마우스 포인터가 켄버스 영역을 벗어났다가 다시 돌아올경우 Object.__corner 값이 정상적인 값을 리턴하지 않고 0을 리턴하기 시작함
* Object.__corner 값이 0을 리턴하면서 계산식이 잘못되어 cropzone이 켄버스 영역을 벗어나게됨


#### 해결
* 불안전한 Object.__corner값을 이용하지 않고 fabricjs개발자가 권장하는 scaling 핸들러의 `fEvent.transform.corner` 값을 통해 선택된 컨트롤을 판별하여 버그 없이 동작하게 함
    * https://github.com/fabricjs/fabric.js/issues/5131
  
---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨