### PR TITLE
fix: fixed undo redo bug for shape menu (fixed #315 #310)

### DIFF
--- a/src/js/action.js
+++ b/src/js/action.js
@@ -299,9 +299,9 @@ export default {
      */
     _shapeAction() {
         return extend({
-            changeShape: changeShapeObject => {
+            changeShape: (changeShapeObject, isSilent) => {
                 if (this.activeObjectId) {
-                    this.changeShape(this.activeObjectId, changeShapeObject);
+                    this.changeShape(this.activeObjectId, changeShapeObject, isSilent);
                 }
             },
             setDrawingShape: shapeType => {

--- a/src/js/command/changeShape.js
+++ b/src/js/command/changeShape.js
@@ -26,14 +26,12 @@ function makeUndoData(options, targetObj, isSilent) {
     snippet.forEachOwnProperties(options, (value, key) => {
         let undoValue = targetObj[key];
 
-        if (!isSilent && key === 'strokeWidth') {
-            undoValue = targetObj.lastStrokeWidthUndoStack;
-            targetObj.lastStrokeWidthUndoStack = targetObj[key];
-
-            undoData.options[key] = undoValue;
-        } else {
-            undoData.options[key] = undoValue;
+        if (!isSilent) {
+            undoValue = targetObj.lastUndoStackForShape[key];
+            targetObj.lastUndoStackForShape[key] = targetObj[key];
         }
+
+        undoData.options[key] = undoValue;
     });
 
     return undoData;
@@ -63,13 +61,12 @@ const command = {
     execute(graphics, id, options, isSilent) {
         const shapeComp = graphics.getComponent(SHAPE);
         const targetObj = graphics.getObject(id);
-        const isRedo = Object.keys(this.undoData).length;
 
         if (!targetObj) {
             return Promise.reject(rejectMessages.noObject);
         }
 
-        if (!isRedo) {
+        if (!this.isRedo()) {
             snippet.extend(this.undoData, makeUndoData(options, targetObj, isSilent));
         }
 

--- a/src/js/component/shape.js
+++ b/src/js/component/shape.js
@@ -181,7 +181,9 @@ class Shape extends Component {
         return new Promise(resolve => {
             const canvas = this.getCanvas();
             options = this._extendOptions(options);
+
             const shapeObj = this._createInstance(type, options);
+            shapeObj.lastStrokeWidthUndoStack = options.strokeWidth;
 
             this._bindEventOnShape(shapeObj);
 

--- a/src/js/component/shape.js
+++ b/src/js/component/shape.js
@@ -183,7 +183,7 @@ class Shape extends Component {
             options = this._extendOptions(options);
 
             const shapeObj = this._createInstance(type, options);
-            shapeObj.lastStrokeWidthUndoStack = options.strokeWidth;
+            shapeObj.lastUndoStackForShape = options;
 
             this._bindEventOnShape(shapeObj);
 

--- a/src/js/consts.js
+++ b/src/js/consts.js
@@ -167,7 +167,7 @@ module.exports = {
     },
 
     defaultShapeStrokeValus: {
-        realTimeEvent: false,
+        realTimeEvent: true,
         min: 2,
         max: 300,
         value: 3

--- a/src/js/imageEditor.js
+++ b/src/js/imageEditor.js
@@ -947,6 +947,7 @@ class ImageEditor {
      *      @param {number} [options.rx] - Radius x value (When type option is 'circle', this options can use)
      *      @param {number} [options.ry] - Radius y value (When type option is 'circle', this options can use)
      *      @param {boolean} [options.isRegular] - Whether resizing shape has 1:1 ratio or not
+     * @param {boolean} isSilent - is silent execution or not
      * @returns {Promise}
      * @example
      * // call after selecting shape object on canvas
@@ -967,8 +968,10 @@ class ImageEditor {
      *     ry: 100
      * });
      */
-    changeShape(id, options) {
-        return this.execute(commands.CHANGE_SHAPE, id, options);
+    changeShape(id, options, isSilent) {
+        const executeMethodName = isSilent ? 'executeSilent' : 'execute';
+
+        return this[executeMethodName](commands.CHANGE_SHAPE, id, options);
     }
 
     /**

--- a/src/js/interface/command.js
+++ b/src/js/interface/command.js
@@ -79,6 +79,14 @@ class Command {
     }
 
     /**
+     * command for redo if undoData exists
+     * @returns {boolean} isRedo
+     */
+    isRedo() {
+        return Object.keys(this.undoData).length;
+    }
+
+    /**
      * Attach execute callabck
      * @param {function} callback - Callback after execution
      * @returns {Command} this

--- a/src/js/ui/shape.js
+++ b/src/js/ui/shape.js
@@ -158,13 +158,14 @@ class Shape extends Submenu {
     /**
      * Change stroke range
      * @param {number} value - stroke range value
+     * @param {boolean} isLast - Is last change
      * @private
      */
-    _changeStrokeRangeHandler(value) {
+    _changeStrokeRangeHandler(value, isLast) {
         this.options.strokeWidth = toInteger(value);
         this.actions.changeShape({
             strokeWidth: value
-        });
+        }, !isLast);
 
         this.actions.setDrawingShape(this.type, this.options);
     }

--- a/test/command.spec.js
+++ b/test/command.spec.js
@@ -288,6 +288,37 @@ describe('commandFactory', () => {
         });
     });
 
+    describe('shapeCommand', () => {
+        let shapeObjectId;
+        const defaultStrokeWidth = 12;
+        beforeEach(done => {
+            invoker.execute(commands.ADD_SHAPE, graphics, 'rect', {
+                strokeWidth: defaultStrokeWidth
+            }).then(shapeObject => {
+                shapeObjectId = shapeObject.id;
+                done();
+            });
+        });
+        it('"changeShape" should set strokeWidth', done => {
+            invoker.execute(commands.CHANGE_SHAPE, graphics, shapeObjectId, {
+                strokeWidth: 50
+            }).then(() => {
+                const shapeObject = graphics.getObject(shapeObjectId);
+                expect(shapeObject.strokeWidth).toBe(50);
+                done();
+            });
+        });
+        it('"redo()" should restore strokeWidth', done => {
+            invoker.execute(commands.CHANGE_SHAPE, graphics, shapeObjectId, {
+                strokeWidth: 50
+            }).then(() => invoker.undo()).then(() => {
+                const shapeObject = graphics.getObject(shapeObjectId);
+                expect(shapeObject.strokeWidth).toBe(defaultStrokeWidth);
+                done();
+            });
+        });
+    });
+
     describe('clearCommand', () => {
         let canvasContext;
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change


### issue

* https://github.com/nhn/tui.image-editor/issues/315
* https://github.com/nhn/tui.image-editor/issues/310
* shape 기능의 `changeShape` 명령에 대한 undo 또는 redo 실행시 상태가 정확히 되돌려지지 않음

### 문제점 파악 및 수정

#### 1. 슬라이더 UI의 drag도중에는 undo 스택에 반영 안되도록 개선 
* rotate 기능에 구현된 부분을 참고하여 변경 (isSilent 플래그를 추가하여 운영)
* strokeWidth 가 변경될때는 마지막 스택의 텍스트 스타일  값을 항상 알고 있도록 변경하고, 그 값을 기준으로 동작 하도록 변경

#### 2. redo 실행시 이미 저장되어 있는 undoData가 새로운 잘못된 값으로  변질 되면서 재차 undo, redo 를 실행하면 정확한 동작을 보장하지 않는 버그 수정

* redo 실행시 이미 undoData가 있으면 값이 변경되지 않도록 수정



