### PR TITLE
feat: undo redo for slider filter (fixed #310)

### DIFF
--- a/src/js/action.js
+++ b/src/js/action.js
@@ -41,14 +41,14 @@ export default {
                 this.ui.rotate.setRangeBarAngle('setAngle', angle);
             }
         };
-        const setFilterSateRangeBarOnAction = filterOptions => {
+        const setFilterStateRangeBarOnAction = filterOptions => {
             if (this.ui.submenu === 'filter') {
                 this.ui.filter.setFilterState(filterOptions);
             }
         };
         const onEndUndoRedo = result => {
             setAngleRangeBarOnAction(result);
-            setFilterSateRangeBarOnAction(result);
+            setFilterStateRangeBarOnAction(result);
 
             return result;
         };

--- a/src/js/action.js
+++ b/src/js/action.js
@@ -41,8 +41,14 @@ export default {
                 this.ui.rotate.setRangeBarAngle('setAngle', angle);
             }
         };
+        const setFilterSateRangeBarOnAction = filterOptions => {
+            if (this.ui.submenu === 'filter') {
+                this.ui.filter.setFilterState(filterOptions);
+            }
+        };
         const onEndUndoRedo = result => {
             setAngleRangeBarOnAction(result);
+            setFilterSateRangeBarOnAction(result);
 
             return result;
         };
@@ -381,9 +387,10 @@ export default {
      */
     _filterAction() {
         return extend({
-            applyFilter: (applying, type, options) => {
+            applyFilter: (applying, type, options, isSilent) => {
+
                 if (applying) {
-                    this.applyFilter(type, options);
+                    this.applyFilter(type, options, isSilent);
                 } else if (this.hasFilter(type)) {
                     this.removeFilter(type);
                 }

--- a/src/js/command/applyFilter.js
+++ b/src/js/command/applyFilter.js
@@ -11,30 +11,45 @@ const {FILTER} = componentNames;
 
 /**
  * Make undoData
- * @param {Graphics} graphics - Graphics instance
  * @param {string} type - Filter type 
- * @param {Component} filterComp - filter component
+ * @param {Object} prevfilterOption - prev Filter options
  * @param {Object} options - Filter options
- *  @param {number} options.maskObjId - masking image object id
- * @param {boolean} isSilent - is silent execution or not
+ * @param {object} cacheUndoData - cached undo data
+ *   @param {object} cacheUndoData.options - filter option
  * @returns {object} - undo data
  */
-function makeUndoData(graphics, type, filterComp, options, isSilent) {
+function makeUndoData(type, prevfilterOption, options, cacheUndoData) {
     const undoData = {};
 
     if (type === 'mask') {
         undoData.object = options.mask;
-        graphics.remove(options.mask);
-    } else if (!isSilent) {
-        const isRedo = !snippet.isUndefined(undoData.options);
+    }
 
-        if (!isRedo) {
-            undoData.options = filterComp.filterChangedStateForUndoStack[type] || null;
-            filterComp.filterChangedStateForUndoStack[type] = snippet.extend({}, options);
-        }
+    if (!cacheUndoData) {
+        undoData.options = prevfilterOption;
+    } else {
+        undoData.options = cacheUndoData.options;
     }
 
     return undoData;
+}
+
+/**
+ * Make mask option
+ * @param {Graphics} graphics - Graphics instance
+ * @param {number} maskObjId - masking image object id
+ * @returns {object} - mask option
+ */
+function makeMaskOption(graphics, maskObjId) {
+    const maskObj = graphics.getObject(maskObjId);
+
+    if (!(maskObj && maskObj.isType('image'))) {
+        return Promise.reject(rejectMessages.invalidParameters);
+    }
+
+    return {
+        mask: maskObj
+    };
 }
 
 const command = {
@@ -53,18 +68,20 @@ const command = {
         const filterComp = graphics.getComponent(FILTER);
 
         if (type === 'mask') {
-            const maskObj = graphics.getObject(options.maskObjId);
-
-            if (!(maskObj && maskObj.isType('image'))) {
-                return Promise.reject(rejectMessages.invalidParameters);
-            }
-
-            options = {
-                mask: maskObj
-            };
+            snippet.extend(options, makeMaskOption(graphics, options.maskObjId));
+            graphics.remove(options.mask);
         }
+        if (!this.isRedo) {
+            const prevfilterOption = filterComp.getOptions(type);
+            const undoData = makeUndoData(type, prevfilterOption, options, this.cacheUndoDataForSilent, isSilent);
 
-        snippet.extend(this.undoData, makeUndoData(graphics, type, filterComp, options, isSilent));
+            if (!isSilent) {
+                snippet.extend(this.undoData, undoData);
+                this.cacheUndoDataForSilent = null;
+            } else if (!this.cacheUndoDataForSilent) {
+                this.cacheUndoDataForSilent = undoData;
+            }
+        }
 
         return filterComp.add(type, options);
     },

--- a/src/js/command/applyFilter.js
+++ b/src/js/command/applyFilter.js
@@ -12,7 +12,7 @@ const {FILTER} = componentNames;
 /**
  * Make undoData
  * @param {Graphics} graphics - Graphics instance
- * @param {string} type - Filter name
+ * @param {string} type - Filter type 
  * @param {Component} filterComp - filter component
  * @param {Object} options - Filter options
  *  @param {number} options.maskObjId - masking image object id
@@ -43,7 +43,7 @@ const command = {
     /**
      * Apply a filter into an image
      * @param {Graphics} graphics - Graphics instance
-     * @param {string} type - Filter name
+     * @param {string} type - Filter type
      * @param {Object} options - Filter options
      *  @param {number} options.maskObjId - masking image object id
      * @param {boolean} isSilent - is silent execution or not

--- a/src/js/command/changeShape.js
+++ b/src/js/command/changeShape.js
@@ -66,7 +66,7 @@ const command = {
             return Promise.reject(rejectMessages.noObject);
         }
 
-        if (!this.isRedo()) {
+        if (!this.isRedo) {
             snippet.extend(this.undoData, makeUndoData(options, targetObj, isSilent));
         }
 

--- a/src/js/command/changeTextStyle.js
+++ b/src/js/command/changeTextStyle.js
@@ -58,12 +58,11 @@ const command = {
     execute(graphics, id, styles, isSilent) {
         const textComp = graphics.getComponent(TEXT);
         const targetObj = graphics.getObject(id);
-        const isRedo = Object.keys(this.undoData).length;
 
         if (!targetObj) {
             return Promise.reject(rejectMessages.noObject);
         }
-        if (!isRedo) {
+        if (!this.isRedo) {
             snippet.extend(this.undoData, makeUndoData(styles, targetObj, isSilent));
         }
 

--- a/src/js/component/filter.js
+++ b/src/js/component/filter.js
@@ -31,8 +31,6 @@ filters.ColorFilter = ColorFilter;
 class Filter extends Component {
     constructor(graphics) {
         super(consts.componentNames.FILTER, graphics);
-
-        this.filterChangedStateForUndoStack = {};
     }
 
     /**

--- a/src/js/component/filter.js
+++ b/src/js/component/filter.js
@@ -13,7 +13,7 @@ import Sharpen from '../extension/sharpen';
 import Emboss from '../extension/emboss';
 import ColorFilter from '../extension/colorFilter';
 
-const {rejectMessages, filterNameMap} = consts;
+const {rejectMessages} = consts;
 const {filters} = fabric.Image;
 filters.Mask = Mask;
 filters.Blur = Blur;

--- a/src/js/component/filter.js
+++ b/src/js/component/filter.js
@@ -13,7 +13,7 @@ import Sharpen from '../extension/sharpen';
 import Emboss from '../extension/emboss';
 import ColorFilter from '../extension/colorFilter';
 
-const {rejectMessages} = consts;
+const {rejectMessages, filterNameMap} = consts;
 const {filters} = fabric.Image;
 filters.Mask = Mask;
 filters.Blur = Blur;
@@ -31,6 +31,8 @@ filters.ColorFilter = ColorFilter;
 class Filter extends Component {
     constructor(graphics) {
         super(consts.componentNames.FILTER, graphics);
+
+        this.filterChangedStateForUndoStack = {};
     }
 
     /**
@@ -58,7 +60,8 @@ class Filter extends Component {
                 canvas.renderAll();
                 resolve({
                     type,
-                    action: 'add'
+                    action: 'add',
+                    options
                 });
             });
         });
@@ -73,6 +76,7 @@ class Filter extends Component {
         return new Promise((resolve, reject) => {
             const sourceImg = this._getSourceImage();
             const canvas = this.getCanvas();
+            const options = this.getOptions(type);
 
             if (!sourceImg.filters.length) {
                 reject(rejectMessages.unsupportedOperation);
@@ -84,7 +88,8 @@ class Filter extends Component {
                 canvas.renderAll();
                 resolve({
                     type,
-                    action: 'remove'
+                    action: 'remove',
+                    options
                 });
             });
         });

--- a/src/js/consts.js
+++ b/src/js/consts.js
@@ -153,6 +153,30 @@ module.exports = {
         'icon-bubble': 'M44 48L34 58V48H12C5.373 48 0 42.627 0 36V12C0 5.373 5.373 0 12 0h40c6.627 0 12 5.373 12 12v24c0 6.627-5.373 12-12 12h-8z'
     },
 
+    filterNameMap: {
+        grayscale: 'grayscale',
+        invert: 'invert',
+        sepia: 'sepia',
+        sepia2: 'vintage',
+        blur: 'blur',
+        sharpen: 'sharpen',
+        emboss: 'emboss',
+        removeWhite: 'removeColor',
+        brightness: 'brightness',
+        contrast: 'contrast',
+        saturation: 'saturation',
+        vintage: 'vintage',
+        polaroid: 'polaroid',
+        noise: 'noise',
+        pixelate: 'pixelate',
+        colorFilter: 'removeColor',
+        tint: 'blendColor',
+        multiply: 'blendColor',
+        blend: 'blendColor',
+        hue: 'hue',
+        gamma: 'gamma'
+    },
+
     defaultRotateRangeValus: {
         realTimeEvent: true,
         min: -360,
@@ -182,34 +206,40 @@ module.exports = {
 
     defaultFilterRangeValus: {
         tintOpacityRange: {
+            realTimeEvent: true,
             min: 0,
             max: 1,
             value: 0.7,
             useDecimal: true
         },
         removewhiteDistanceRange: {
+            realTimeEvent: true,
             min: 0,
             max: 1,
             value: 0.2,
             useDecimal: true
         },
         brightnessRange: {
+            realTimeEvent: true,
             min: -1,
             max: 1,
             value: 0,
             useDecimal: true
         },
         noiseRange: {
+            realTimeEvent: true,
             min: 0,
             max: 1000,
             value: 100
         },
         pixelateRange: {
+            realTimeEvent: true,
             min: 2,
             max: 20,
             value: 4
         },
         colorfilterThresholeRange: {
+            realTimeEvent: true,
             min: 0,
             max: 1,
             value: 0.2,

--- a/src/js/consts.js
+++ b/src/js/consts.js
@@ -157,7 +157,6 @@ module.exports = {
         grayscale: 'grayscale',
         invert: 'invert',
         sepia: 'sepia',
-        sepia2: 'vintage',
         blur: 'blur',
         sharpen: 'sharpen',
         emboss: 'emboss',

--- a/src/js/consts.js
+++ b/src/js/consts.js
@@ -153,29 +153,6 @@ module.exports = {
         'icon-bubble': 'M44 48L34 58V48H12C5.373 48 0 42.627 0 36V12C0 5.373 5.373 0 12 0h40c6.627 0 12 5.373 12 12v24c0 6.627-5.373 12-12 12h-8z'
     },
 
-    filterNameMap: {
-        grayscale: 'grayscale',
-        invert: 'invert',
-        sepia: 'sepia',
-        blur: 'blur',
-        sharpen: 'sharpen',
-        emboss: 'emboss',
-        removeWhite: 'removeColor',
-        brightness: 'brightness',
-        contrast: 'contrast',
-        saturation: 'saturation',
-        vintage: 'vintage',
-        polaroid: 'polaroid',
-        noise: 'noise',
-        pixelate: 'pixelate',
-        colorFilter: 'removeColor',
-        tint: 'blendColor',
-        multiply: 'blendColor',
-        blend: 'blendColor',
-        hue: 'hue',
-        gamma: 'gamma'
-    },
-
     defaultRotateRangeValus: {
         realTimeEvent: true,
         min: -360,

--- a/src/js/imageEditor.js
+++ b/src/js/imageEditor.js
@@ -1268,6 +1268,7 @@ class ImageEditor {
      * @param {string} type - Filter type
      * @param {Object} options - Options to apply filter
      *  @param {number} options.maskObjId - masking image object id
+     * @param {boolean} isSilent - is silent execution or not
      * @returns {Promise<FilterResult, ErrorMsg>}
      * @example
      * imageEditor.applyFilter('Grayscale');
@@ -1279,8 +1280,10 @@ class ImageEditor {
      *     console.log('error: ', message);
      * });;
      */
-    applyFilter(type, options) {
-        return this.execute(commands.APPLY_FILTER, type, options);
+    applyFilter(type, options, isSilent) {
+        const executeMethodName = isSilent ? 'executeSilent' : 'execute';
+
+        return this[executeMethodName](commands.APPLY_FILTER, type, options);
     }
 
     /**

--- a/src/js/interface/command.js
+++ b/src/js/interface/command.js
@@ -2,11 +2,11 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhn.com>
  * @fileoverview Command interface
  */
+import snippet from 'tui-code-snippet';
 import errorMessage from '../factory/errorMessage';
 
 const createMessage = errorMessage.create;
 const errorTypes = errorMessage.types;
-let cacheUndoDataForSilent = null;
 
 /**
  * Command class
@@ -87,12 +87,25 @@ class Command {
         return Object.keys(this.undoData).length;
     }
 
-    get cacheUndoDataForSilent() {
-        return cacheUndoDataForSilent;
-    }
+    /**
+     * Set undoData action
+     * @param {Object} undoData - maked undo data
+     * @param {Object} chchedUndoDataForSilent - chched undo data
+     * @param {boolean} isSilent - is silent execution or not
+     * @returns {Object} chchedUndoDataForSilent
+     */
+    setUndoData(undoData, chchedUndoDataForSilent, isSilent) {
+        if (chchedUndoDataForSilent) {
+            undoData = chchedUndoDataForSilent;
+        }
+        if (!isSilent) {
+            snippet.extend(this.undoData, undoData);
+            chchedUndoDataForSilent = null;
+        } else if (!chchedUndoDataForSilent) {
+            chchedUndoDataForSilent = undoData;
+        }
 
-    set cacheUndoDataForSilent(value) {
-        cacheUndoDataForSilent = value;
+        return chchedUndoDataForSilent;
     }
 
     /**

--- a/src/js/interface/command.js
+++ b/src/js/interface/command.js
@@ -6,6 +6,7 @@ import errorMessage from '../factory/errorMessage';
 
 const createMessage = errorMessage.create;
 const errorTypes = errorMessage.types;
+let cacheUndoDataForSilent = null;
 
 /**
  * Command class
@@ -82,8 +83,16 @@ class Command {
      * command for redo if undoData exists
      * @returns {boolean} isRedo
      */
-    isRedo() {
+    get isRedo() {
         return Object.keys(this.undoData).length;
+    }
+
+    get cacheUndoDataForSilent() {
+        return cacheUndoDataForSilent;
+    }
+
+    set cacheUndoDataForSilent(value) {
+        cacheUndoDataForSilent = value;
     }
 
     /**

--- a/src/js/ui/filter.js
+++ b/src/js/ui/filter.js
@@ -72,6 +72,44 @@ class Filter extends Submenu {
     }
 
     /**
+     * Destroy
+     */
+    destroy() {
+        this._removeEvent();
+        snippet.forEach(this, (value, key) => {
+            this[key] = null;
+        });
+    }
+
+    /**
+     * Remove event for filter
+     */
+    removeEvent() {
+        snippet.forEach(FILTER_OPTIONS, filter => {
+            const filterCheckElement = this.selector(`.tie-${filter}`);
+            const filterNameCamelCase = toCamelCase(filter);
+
+            filterCheckElement.removeEventListener('change', this.handler[filterNameCamelCase]);
+        });
+
+        this._els.removewhiteDistanceRange.off();
+        this._els.colorfilterThresholeRange.off();
+        this._els.pixelateRange.off();
+        this._els.noiseRange.off();
+        this._els.brightnessRange.off();
+        this._els.filterBlendColor.off();
+        this._els.filterMultiplyColor.off();
+        this._els.filterTintColor.off();
+        this._els.tintOpacity.off();
+        this._els.filterMultiplyColor.off();
+        this._els.filterTintColor.off();
+        this._els.filterBlendColor.off();
+
+        this._els.blendType.removeEventListener('change', this.handler.changeBlendFilter);
+        this._els.blendType.removeEventListener('click', this.handler.changeBlendFilter);
+    }
+
+    /**
      * Add event for filter
      * @param {Object} actions - actions for crop
      *   @param {Function} actions.applyFilter - apply filter option
@@ -81,12 +119,18 @@ class Filter extends Submenu {
         const changeFilterStateForRange =
             filterName => (value, isLast) => this._changeFilterState(applyFilter, filterName, isLast);
 
+        this.handler = {
+            changeBlendFilter: changeFilterState('blend'),
+            blandTypeClick: event => event.stopPropagation()
+        };
+
         snippet.forEach(FILTER_OPTIONS, filter => {
             const filterCheckElement = this.selector(`.tie-${filter}`);
             const filterNameCamelCase = toCamelCase(filter);
             this.checkedMap[filterNameCamelCase] = filterCheckElement;
+            this.handler[filterNameCamelCase] = changeFilterState(filterNameCamelCase);
 
-            filterCheckElement.addEventListener('change', changeFilterState(filterNameCamelCase));
+            filterCheckElement.addEventListener('change', this.handler[filterNameCamelCase]);
         });
 
         this._els.removewhiteDistanceRange.on('change', changeFilterStateForRange('removeWhite'));
@@ -94,12 +138,12 @@ class Filter extends Submenu {
         this._els.pixelateRange.on('change', changeFilterStateForRange('pixelate'));
         this._els.noiseRange.on('change', changeFilterStateForRange('noise'));
         this._els.brightnessRange.on('change', changeFilterStateForRange('brightness'));
-        this._els.blendType.addEventListener('change', changeFilterState('blend'));
-        this._els.filterBlendColor.on('change', changeFilterState('blend'));
+        this._els.blendType.addEventListener('change', this.handler.changeBlendFilter);
+        this._els.filterBlendColor.on('change', this.handler.changeBlendFilter);
         this._els.filterMultiplyColor.on('change', changeFilterState('multiply'));
         this._els.filterTintColor.on('change', changeFilterState('tint'));
         this._els.tintOpacity.on('change', changeFilterStateForRange('tint'));
-        this._els.blendType.addEventListener('click', event => event.stopPropagation());
+        this._els.blendType.addEventListener('click', this.handler.blandTypeClick);
         this._els.filterMultiplyColor.on('changeShow', this.colorPickerChangeShow.bind(this));
         this._els.filterTintColor.on('changeShow', this.colorPickerChangeShow.bind(this));
         this._els.filterBlendColor.on('changeShow', this.colorPickerChangeShow.bind(this));

--- a/src/js/ui/filter.js
+++ b/src/js/ui/filter.js
@@ -4,7 +4,7 @@ import Range from './tools/range';
 import Submenu from './submenuBase';
 import templateHtml from './template/submenu/filter';
 import {toInteger, toCamelCase} from '../util';
-import {defaultFilterRangeValus as FILTER_RANGE, filterNameMap} from '../consts';
+import {defaultFilterRangeValus as FILTER_RANGE} from '../consts';
 
 const PICKER_CONTROL_HEIGHT = '130px';
 const BLEND_OPTIONS = ['add', 'diff', 'subtract', 'multiply', 'screen', 'lighten', 'darken'];
@@ -25,6 +25,29 @@ const FILTER_OPTIONS = [
     'multiply',
     'blend'
 ];
+
+const filterNameMap = {
+    grayscale: 'grayscale',
+    invert: 'invert',
+    sepia: 'sepia',
+    blur: 'blur',
+    sharpen: 'sharpen',
+    emboss: 'emboss',
+    removeWhite: 'removeColor',
+    brightness: 'brightness',
+    contrast: 'contrast',
+    saturation: 'saturation',
+    vintage: 'vintage',
+    polaroid: 'polaroid',
+    noise: 'noise',
+    pixelate: 'pixelate',
+    colorFilter: 'removeColor',
+    tint: 'blendColor',
+    multiply: 'blendColor',
+    blend: 'blendColor',
+    hue: 'hue',
+    gamma: 'gamma'
+};
 
 /**
  * Filter ui class
@@ -82,6 +105,13 @@ class Filter extends Submenu {
         this._els.filterBlendColor.on('changeShow', this.colorPickerChangeShow.bind(this));
     }
 
+    /**
+     * Set filter for undo changed
+     * @param {Object} chagedFilterInfos - changed command infos
+     *   @param {string} type - filter type
+     *   @param {string} action - add or remove
+     *   @param {Object} options - filter options
+     */
     setFilterState(chagedFilterInfos) {
         const {type, options, action} = chagedFilterInfos;
         const filterName = this._getFilterNameFromOptions(type, options);
@@ -94,6 +124,12 @@ class Filter extends Submenu {
         this.checkedMap[filterName].checked = !isRemove;
     }
 
+    /**
+     * Set filter for undo changed
+     * @param {string} filterName - filter name
+     * @param {Object} options - filter options
+     * @private
+     */
     _setFilterState(filterName, options) { // eslint-disable-line
         if (filterName === 'colorFilter') {
             this._els.colorfilterThresholeRange.value = options.distance;
@@ -115,6 +151,13 @@ class Filter extends Submenu {
         }
     }
 
+    /**
+     * Get filter name
+     * @param {string} type - filter type
+     * @param {Object} options - filter options
+     * @returns {string} filter name
+     * @private
+     */
     _getFilterNameFromOptions(type, options) {
         let filterName = type;
 

--- a/src/js/ui/filter.js
+++ b/src/js/ui/filter.js
@@ -54,7 +54,7 @@ class Filter extends Submenu {
      *   @param {Function} actions.applyFilter - apply filter option
      */
     addEvent({applyFilter}) {
-        const changeRangeValue = filterName => this._changeRangeValue.bind(this, applyFilter, filterName);
+        const changeRangeValue = filterName => this._changeFilterState.bind(this, applyFilter, filterName);
         const changeCheckBox = filterName => this._changeFilterCheckbox.bind(this, applyFilter, filterName);
         const changeColor = filterName => this._changeFilterColor.bind(this, applyFilter, filterName);
 
@@ -72,14 +72,11 @@ class Filter extends Submenu {
         this._els.noiseRange.on('change', changeRangeValue('noise'));
         this._els.brightnessRange.on('change', changeRangeValue('brightness'));
         this._els.blendType.addEventListener('change', changeRangeValue('blend'));
-
         this._els.filterBlendColor.on('change', changeColor('blend'));
         this._els.filterMultiplyColor.on('change', changeColor('multiply'));
         this._els.filterTintColor.on('change', changeColor('tint'));
-
         this._els.tintOpacity.on('change', changeRangeValue('tint'));
         this._els.blendType.addEventListener('click', event => event.stopPropagation());
-
         this._els.filterMultiplyColor.on('changeShow', this.colorPickerChangeShow.bind(this));
         this._els.filterTintColor.on('changeShow', this.colorPickerChangeShow.bind(this));
         this._els.filterBlendColor.on('changeShow', this.colorPickerChangeShow.bind(this));
@@ -88,17 +85,16 @@ class Filter extends Submenu {
     setFilterState(chagedFilterInfos) {
         const {type, options, action} = chagedFilterInfos;
         const filterName = this._getFilterNameFromOptions(type, options);
-        if (action === 'add') {
-            this.checkedMap[filterName].checked = true;
-            this._setFilterAdd(filterName, options);
-        }
 
         if (action === 'remove') {
             this.checkedMap[filterName].checked = false;
+        } else {
+            this.checkedMap[filterName].checked = true;
+            this._setFilterState(filterName, options);
         }
     }
 
-    _setFilterAdd(filterName, options) {
+    _setFilterState(filterName, options) { // eslint-disable-line
         if (filterName === 'colorFilter') {
             this._els.colorfilterThresholeRange.value = options.distance;
         } else if (filterName === 'removeWhite') {
@@ -136,11 +132,11 @@ class Filter extends Submenu {
     }
 
     _changeFilterColor(applyFilter, filterName) {
-        this._changeRangeValue(applyFilter, filterName, null, true);
+        this._changeFilterState(applyFilter, filterName, null, true);
     }
 
     _changeFilterCheckbox(applyFilter, filterName) {
-        this._changeRangeValue(applyFilter, filterName, null, true);
+        this._changeFilterState(applyFilter, filterName, null, true);
     }
 
     /**
@@ -150,7 +146,7 @@ class Filter extends Submenu {
      * @param {string} value - filter value
      * @param {boolean} isLast - Is last change
      */
-    _changeRangeValue(applyFilter, filterName, value, isLast) {
+    _changeFilterState(applyFilter, filterName, value, isLast) {
         const apply = this.checkedMap[filterName].checked;
         const type = filterNameMap[filterName];
 

--- a/src/js/ui/template/submenu/filter.js
+++ b/src/js/ui/template/submenu/filter.js
@@ -26,7 +26,7 @@ export default ({locale}) => (`
                 </div>
                 <div class="tui-image-editor-checkbox">
                     <label>
-                        <input type="checkbox" class="tie-sepia2">
+                        <input type="checkbox" class="tie-vintage">
                         <span>${locale.localize('Sepia2')}</span>
                     </label>
                 </div>

--- a/test/filter.spec.js
+++ b/test/filter.spec.js
@@ -8,17 +8,18 @@ describe('Filter', () => {
     let imageEditor;
     const imageURL = 'base/test/fixtures/sampleImage.jpg';
 
-    beforeAll(done => {
+    beforeEach(done => {
         imageEditor = new ImageEditor(document.createElement('div'), {
             cssMaxWidth: 700,
             cssMaxHeight: 500
         });
         imageEditor.loadImageFromURL(imageURL, 'sampleImage').then(() => {
+            imageEditor.clearUndoStack();
             done();
         });
     });
 
-    afterAll(() => {
+    afterEach(() => {
         imageEditor.destroy();
     });
 
@@ -32,7 +33,21 @@ describe('Filter', () => {
         });
     });
 
+    it('applyFilter() can not add undo stack at isSilent', done => {
+        const isSilent = true;
+
+        imageEditor.applyFilter('colorFilter', {}, isSilent).then(() => {
+            expect(imageEditor.isEmptyUndoStack()).toBe(true);
+            done();
+        })['catch'](() => {
+            fail();
+            done();
+        });
+    });
+
     it('hasFilter', () => {
+        imageEditor.applyFilter('colorFilter');
+
         expect(imageEditor.hasFilter('invert')).toBe(false);
         expect(imageEditor.hasFilter('colorFilter')).toBe(true);
     });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

#### issue

* https://github.com/nhn/tui.image-editor/issues/310
* filter 의 slider UI에서 Drag 하는 동안에는 undoStack에 반영되면 안됨


#### 슬라이더 UI의 drag도중에는 undo 스택에 반영 안되도록 개선 
* rotate 기능에 구현된 부분을 참고하여 변경 (isSilent 플래그를 추가하여 운영)


#### 불필요한 sepia2: 'vintage' mapping을 제거 하고 vintage: 'vintage' 만 남김
