### PR TITLE
Feat/cropzone fix ratio

### DIFF
--- a/src/js/component/cropper.js
+++ b/src/js/component/cropper.js
@@ -11,6 +11,7 @@ import {clamp, fixFloatingPoint} from '../util';
 
 const MOUSE_MOVE_THRESHOLD = 10;
 const DEFAULT_OPTION = {
+    presetRatio: null,
     top: -10,
     left: -10,
     height: 1,
@@ -308,8 +309,7 @@ class Cropper extends Component {
         canvas.selection = false;
         canvas.remove(cropzone);
 
-        cropzone.set(presetRatio ? this._getPresetCropSizePosition(presetRatio) : DEFAULT_OPTION);
-        cropzone.options.presetRatio = presetRatio;
+        cropzone.set(presetRatio ? this._getPresetPropertiesForCropSize(presetRatio) : DEFAULT_OPTION);
 
         canvas.add(cropzone);
         canvas.selection = true;
@@ -320,12 +320,12 @@ class Cropper extends Component {
     }
 
     /**
-     * Set a cropzone square
+     * get a cropzone square info
      * @param {number} presetRatio - preset ratio
-     * @returns {{left: number, top: number, width: number, height: number}}
+     * @returns {{presetRatio: number, left: number, top: number, width: number, height: number}}
      * @private
      */
-    _getPresetCropSizePosition(presetRatio) {
+    _getPresetPropertiesForCropSize(presetRatio) {
         const canvas = this.getCanvas();
         const originalWidth = canvas.getWidth();
         const originalHeight = canvas.getHeight();
@@ -343,6 +343,7 @@ class Cropper extends Component {
         [width, height] = snippet.map([width, height], sizeValue => fixFloatingPoint(sizeValue * scaleHeight));
 
         return {
+            presetRatio,
             top: (originalHeight - height) / 2,
             left: (originalWidth - width) / 2,
             width,

--- a/src/js/component/cropper.js
+++ b/src/js/component/cropper.js
@@ -97,6 +97,7 @@ class Cropper extends Component {
             lockScalingFlip: true,
             lockRotation: true
         }, this.graphics.cropSelectionStyle);
+        // this._cropzone.lockUniScaling = true;
 
         canvas.discardActiveObject();
         canvas.add(this._cropzone);
@@ -308,6 +309,7 @@ class Cropper extends Component {
         canvas.remove(cropzone);
 
         cropzone.set(presetRatio ? this._getPresetCropSizePosition(presetRatio) : DEFAULT_OPTION);
+        cropzone.options.presetRatio = presetRatio;
 
         canvas.add(cropzone);
         canvas.selection = true;

--- a/src/js/component/cropper.js
+++ b/src/js/component/cropper.js
@@ -98,7 +98,6 @@ class Cropper extends Component {
             lockScalingFlip: true,
             lockRotation: true
         }, this.graphics.cropSelectionStyle);
-        // this._cropzone.lockUniScaling = true;
 
         canvas.discardActiveObject();
         canvas.add(this._cropzone);

--- a/src/js/extension/cropzone.js
+++ b/src/js/extension/cropzone.js
@@ -334,41 +334,45 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
      * @private
      */
     _calcScalingSizeFromPointer(pointer, selectedCorner) {
-        const pointerX = pointer.x;
-        const pointerY = pointer.y;
-        const tlScalingSize = this._calcTopLeftScalingSizeFromPointer(pointerX, pointerY);
-        const brScalingSize = this._calcBottomRightScalingSizeFromPointer(pointerX, pointerY);
+        const isCornerTypeValid = this._cornerTypeValid(selectedCorner);
+        const scalingMathodName = `_resize${selectedCorner.toUpperCase()}`;
 
-        if (selectedCorner === CORNER_TYPE_TOP_LEFT) {
-            return this.resizeTL(pointerX, pointerY);
-        } else if (selectedCorner === CORNER_TYPE_MIDDLE_TOP) {
-            return this.resizeT(pointerY);
-        } else if (selectedCorner === CORNER_TYPE_TOP_RIGHT) {
-            return this.resizeTR(pointerX, pointerY);
-        } else if (selectedCorner === CORNER_TYPE_BOTTOM_LEFT) {
-            return this.resizeBL(pointerX, pointerY);
-        } else if (selectedCorner === CORNER_TYPE_BOTTOM_RIGHT) {
-            return this.resizeBR(pointerX, pointerY);
-        } else if (selectedCorner === CORNER_TYPE_MIDDLE_BOTTOM) {
-            return this.resizeB(pointerY);
-        } else if (selectedCorner === CORNER_TYPE_MIDDLE_LEFT) {
-            return this.resizeL(pointerX);
-        } else if (selectedCorner === CORNER_TYPE_MIDDLE_RIGHT) {
-            return this.resizeR(pointerX);
-        }
-
-        /*
-         * @todo: 일반 객체에서 shift 조합키를 누르면 free size scaling이 됨 --> 확인해볼것
-         *      canvas.class.js // _scaleObject: function(...){...}
-         */
-        return this._makeScalingSettings(tlScalingSize, brScalingSize, selectedCorner);
+        return isCornerTypeValid && this[scalingMathodName](pointer);
     },
 
-    adjustRatioSize({width, height, presetRatio, scaleTo, maxWidth, maxHeight}) {
+    /**
+     * Align with cropzone ratio
+     * @param {string} selectedCorner - selected corner type
+     * @returns {{width: number, height: number}}
+     * @private
+     */
+    _cornerTypeValid(selectedCorner) {
+        return [CORNER_TYPE_TOP_LEFT,
+            CORNER_TYPE_TOP_RIGHT,
+            CORNER_TYPE_MIDDLE_TOP,
+            CORNER_TYPE_MIDDLE_LEFT,
+            CORNER_TYPE_MIDDLE_RIGHT,
+            CORNER_TYPE_MIDDLE_BOTTOM,
+            CORNER_TYPE_BOTTOM_LEFT,
+            CORNER_TYPE_BOTTOM_RIGHT].indexOf(selectedCorner) >= 0;
+    },
+
+    /**
+     * Align with cropzone ratio
+     * @param {Object} position - Mouse position
+     *   @param {number} width - cropzone width
+     *   @param {number} height - cropzone height
+     *   @param {number} ratio - cropzone ratio
+     *   @param {number} maxWidth - limit max width
+     *   @param {number} maxHeight - limit max height
+     * @returns {{width: number, height: number}}
+     * @private
+     */
+    adjustRatioSize({width, height, ratio, scaleTo, maxWidth, maxHeight}) {
         if (scaleTo === 'width') {
-            height = width / presetRatio;
+            height = width / ratio;
         } else {
-            width = height * presetRatio;
+            width = height * ratio;
         }
 
         const maxScaleFactor = Math.min(maxWidth / width, maxHeight / height);
@@ -382,7 +386,15 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
         };
     },
 
-    resizeTL(x, y) {
+    /**
+     * Calc scaling dimension with control TL
+     * @param {Object} position - Mouse position
+     *   @param {string} x - Mouse position x
+     *   @param {string} y - Mouse position y
+     * @returns {{left: number, top: number, width: number, height: number}}
+     * @private
+     */
+    _resizeTL({x, y}) {
         // const {width: maxX, height: maxY} = this.canvas;
         const {presetRatio} = this.options;
         const rect = this.getBoundingRect(false, true);
@@ -423,7 +435,15 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
         };
     },
 
-    resizeT(y) {
+    /**
+     * Calc scaling dimension with control MT
+     * @param {Object} position - Mouse position
+     *   @param {string} x - Mouse position x
+     *   @param {string} y - Mouse position y
+     * @returns {{left: number, top: number, width: number, height: number}}
+     * @private
+     */
+    _resizeMT({y}) {
         const {width: maxX} = this.canvas;
         const {presetRatio} = this.options;
         const rect = this.getBoundingRect(false, true);
@@ -457,7 +477,16 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
             width
         };
     },
-    resizeTR(x, y) {
+
+    /**
+     * Calc scaling dimension with control TR
+     * @param {Object} position - Mouse position
+     *   @param {string} x - Mouse position x
+     *   @param {string} y - Mouse position y
+     * @returns {{left: number, top: number, width: number, height: number}}
+     * @private
+     */
+    _resizeTR({x, y}) {
         const {width: maxX} = this.canvas;
         const {presetRatio} = this.options;
         const rect = this.getBoundingRect(false, true);
@@ -497,7 +526,15 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
         };
     },
 
-    resizeBL(x, y) {
+    /**
+     * Calc scaling dimension with control BL
+     * @param {Object} position - Mouse position
+     *   @param {string} x - Mouse position x
+     *   @param {string} y - Mouse position y
+     * @returns {{left: number, top: number, width: number, height: number}}
+     * @private
+     */
+    _resizeBL({x, y}) {
         const {height: maxY} = this.canvas;
         const {presetRatio} = this.options;
         const rect = this.getBoundingRect(false, true);
@@ -539,7 +576,15 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
         };
     },
 
-    resizeBR(x, y) {
+    /**
+     * Calc scaling dimension with control BR
+     * @param {Object} position - Mouse position
+     *   @param {string} x - Mouse position x
+     *   @param {string} y - Mouse position y
+     * @returns {{left: number, top: number, width: number, height: number}}
+     * @private
+     */
+    _resizeBR({x, y}) {
         const {width: maxX, height: maxY} = this.canvas;
         const {presetRatio} = this.options;
         const rect = this.getBoundingRect(false, true);
@@ -579,7 +624,15 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
         };
     },
 
-    resizeB(y) {
+    /**
+     * Calc scaling dimension with control MB
+     * @param {Object} position - Mouse position
+     *   @param {string} x - Mouse position x
+     *   @param {string} y - Mouse position y
+     * @returns {{left: number, top: number, width: number, height: number}}
+     * @private
+     */
+    _resizeMB({y}) {
         const {width: maxX, height: maxY} = this.canvas;
         const {presetRatio} = this.options;
         const rect = this.getBoundingRect(false, true);
@@ -610,7 +663,15 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
         };
     },
 
-    resizeL(x) {
+    /**
+     * Calc scaling dimension with control ML
+     * @param {Object} position - Mouse position
+     *   @param {string} x - Mouse position x
+     *   @param {string} y - Mouse position y
+     * @returns {{left: number, top: number, width: number, height: number}}
+     * @private
+     */
+    _resizeML({x}) {
         const {height: maxY} = this.canvas;
         const {presetRatio} = this.options;
         const rect = this.getBoundingRect(false, true);
@@ -646,12 +707,14 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
     },
 
     /**
-     * Calc scaling size with control R
-     * @param {number} x - Mouse position X
+     * Calc scaling dimension with control MR
+     * @param {Object} position - Mouse position
+     *   @param {string} x - Mouse position x
+     *   @param {string} y - Mouse position y
      * @returns {{left: number, top: number, width: number, height: number}}
      * @private
      */
-    resizeR(x) {
+    _resizeMR({x}) {
         const {width: maxX, height: maxY} = this.canvas;
         const {presetRatio} = this.options;
         const rect = this.getBoundingRect(false, true);
@@ -681,120 +744,6 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
             height
         };
     },
-
-    /**
-     * Calc scaling size(position + dimension) from left-top corner
-     * @param {number} x - Mouse position X
-     * @param {number} y - Mouse position Y
-     * @returns {{top: number, left: number, width: number, height: number}}
-     * @private
-     */
-    _calcTopLeftScalingSizeFromPointer(x, y) { // eslint-disable-line
-        const rect = this.getBoundingRect(false, true);
-        const bottom = rect.height + this.top;
-        const right = rect.width + this.left;
-        let top = clamp(y, 0, bottom - 1); // 0 <= top <= (bottom - 1)
-        let left = clamp(x, 0, right - 1); // 0 <= left <= (right - 1)
-
-        // When scaling "Top-Left corner": It fixes right and bottom coordinates
-        return {
-            top,
-            left,
-            width: right - left,
-            height: bottom - top
-        };
-    },
-
-    /**
-     * Calc scaling size from right-bottom corner
-     * @param {number} x - Mouse position X
-     * @param {number} y - Mouse position Y
-     * @returns {{width: number, height: number}}
-     * @private
-     */
-    _calcBottomRightScalingSizeFromPointer(x, y) { //eslint-disable-line
-        const {width: maxX, height: maxY} = this.canvas;
-        const {left, top} = this;
-
-        let width = clamp(x, (left + 1), maxX) - left; // (width = x - left), (left + 1 <= x <= maxX)
-        let height = clamp(y, (top + 1), maxY) - top; // (height = y - top), (top + 1 <= y <= maxY)
-        const right = width + left;
-        const bottom = height + top;
-
-        // When scaling "Bottom-Right corner": It fixes left and top coordinates
-        return {
-            width,
-            height
-        };
-    },
-
-    /* eslint-disable complexity */
-    /**
-     * Make scaling settings
-     * @param {{width: number, height: number, left: number, top: number}} tl - Top-Left setting
-     * @param {{width: number, height: number}} br - Bottom-Right setting
-     * @param {string} selectedCorner - selected corner type
-     * @returns {{width: ?number, height: ?number, left: ?number, top: ?number}} Position setting
-     * @private
-     */
-    _makeScalingSettings(tl, br, selectedCorner) {
-        const tlWidth = tl.width;
-        const tlHeight = tl.height;
-        const brHeight = br.height;
-        const brWidth = br.width;
-        const tlLeft = tl.left;
-        const tlTop = tl.top;
-        let settings;
-
-        switch (selectedCorner) {
-            case CORNER_TYPE_TOP_LEFT:
-                settings = tl;
-                break;
-            case CORNER_TYPE_TOP_RIGHT:
-                settings = {
-                    width: brWidth,
-                    height: tlHeight,
-                    top: tlTop
-                };
-                break;
-            case CORNER_TYPE_BOTTOM_LEFT:
-                settings = {
-                    width: tlWidth,
-                    height: brHeight,
-                    left: tlLeft
-                };
-                break;
-            case CORNER_TYPE_BOTTOM_RIGHT:
-                settings = br;
-                break;
-            case CORNER_TYPE_MIDDLE_LEFT:
-                settings = {
-                    width: tlWidth,
-                    left: tlLeft
-                };
-                break;
-            case CORNER_TYPE_MIDDLE_TOP:
-                settings = {
-                    height: tlHeight,
-                    top: tlTop
-                };
-                break;
-            case CORNER_TYPE_MIDDLE_RIGHT:
-                settings = {
-                    width: brWidth
-                };
-                break;
-            case CORNER_TYPE_MIDDLE_BOTTOM:
-                settings = {
-                    height: brHeight
-                };
-                break;
-            default:
-                break;
-        }
-
-        return settings;
-    }, /* eslint-enable complexity */
 
     /**
      * Return the whether this cropzone is valid

--- a/src/js/extension/cropzone.js
+++ b/src/js/extension/cropzone.js
@@ -63,17 +63,6 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
             [events.OBJECT_SCALED]: NOOP_FUNCTION
         };
         this.on({
-            'mousedown': e => {
-                if (e.transform.corner) {
-                    this.dragStartPoint = {
-                        x: e.pointer.x,
-                        y: e.pointer.y
-                    };
-                }
-            },
-            'mouseup': () => {
-                this.dragStartPoint = null;
-            },
             'moving': this._onMoving.bind(this),
             'scaling': this._onScaling.bind(this)
         });
@@ -368,11 +357,11 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
      * @returns {{width: number, height: number}}
      * @private
      */
-    adjustRatioSize({width, height, ratio, scaleTo, maxWidth, maxHeight}) {
+    adjustRatioSize({width, height, scaleTo, maxWidth, maxHeight}) {
         if (scaleTo === 'width') {
-            height = width / ratio;
+            height = width / this.presetRatio;
         } else {
-            width = height * ratio;
+            width = height * this.presetRatio;
         }
 
         const maxScaleFactor = Math.min(maxWidth / width, maxHeight / height);
@@ -395,10 +384,7 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
      * @private
      */
     _resizeTL({x, y}) {
-        // const {width: maxX, height: maxY} = this.canvas;
-        const {presetRatio} = this.options;
         const rect = this.getBoundingRect(false, true);
-
         const bottom = rect.height + rect.top;
         const right = rect.width + rect.left;
 
@@ -410,26 +396,22 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
         let width = clamp(right - x, minWidth, maxWidth);
         let height = clamp(bottom - y, minHeight, maxHeight);
 
-        if (this.dragStartPoint && presetRatio) {
+        if (this.presetRatio) {
             const dx = rect.left - x;
             const dy = rect.top - y;
             const scaleTo = dx > dy ? 'width' : 'height';
             ({width, height} = this.adjustRatioSize({
                 width,
                 height,
-                presetRatio,
                 scaleTo,
                 maxWidth,
                 maxHeight
             }));
         }
 
-        const left = right - width;
-        const top = bottom - height;
-
         return {
-            left,
-            top,
+            left: right - width,
+            top: bottom - height,
             width,
             height
         };
@@ -445,7 +427,6 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
      */
     _resizeMT({y}) {
         const {width: maxX} = this.canvas;
-        const {presetRatio} = this.options;
         const rect = this.getBoundingRect(false, true);
         const bottom = rect.height + rect.top;
 
@@ -457,11 +438,10 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
         const {left} = rect;
         let {width} = rect;
 
-        if (this.dragStartPoint && presetRatio) {
+        if (this.presetRatio) {
             ({width, height} = this.adjustRatioSize({
                 width,
                 height,
-                presetRatio,
                 scaleTo: 'height',
                 maxWidth,
                 maxHeight
@@ -488,7 +468,6 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
      */
     _resizeTR({x, y}) {
         const {width: maxX} = this.canvas;
-        const {presetRatio} = this.options;
         const rect = this.getBoundingRect(false, true);
 
         const right = rect.width + rect.left;
@@ -502,14 +481,13 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
         let width = clamp(x - rect.left, minWidth, maxWidth);
         let height = clamp(bottom - y, minHeight, maxHeight);
 
-        if (this.dragStartPoint && presetRatio) {
+        if (this.presetRatio) {
             const dx = x - right;
             const dy = rect.top - y;
             const scaleTo = dx > dy ? 'width' : 'height';
             ({width, height} = this.adjustRatioSize({
                 width,
                 height,
-                presetRatio,
                 scaleTo,
                 maxWidth,
                 maxHeight
@@ -536,7 +514,6 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
      */
     _resizeBL({x, y}) {
         const {height: maxY} = this.canvas;
-        const {presetRatio} = this.options;
         const rect = this.getBoundingRect(false, true);
 
         const right = rect.width + rect.left;
@@ -551,7 +528,7 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
         let width = clamp(right - x, minWidth, maxWidth);
         let height = clamp(y - rect.top, minHeight, maxHeight);
 
-        if (this.dragStartPoint && presetRatio) {
+        if (this.presetRatio) {
             const dx = rect.left - x;
             const dy = y - bottom;
             const scaleTo = dx > dy ? 'width' : 'height';
@@ -559,7 +536,6 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
             ({width, height} = this.adjustRatioSize({
                 width,
                 height,
-                presetRatio,
                 scaleTo,
                 maxWidth,
                 maxHeight
@@ -586,7 +562,6 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
      */
     _resizeBR({x, y}) {
         const {width: maxX, height: maxY} = this.canvas;
-        const {presetRatio} = this.options;
         const rect = this.getBoundingRect(false, true);
 
         const bottom = rect.height + rect.top;
@@ -601,7 +576,7 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
         let width = clamp(x - rect.left, minWidth, maxWidth);
         let height = clamp(y - rect.top, minHeight, maxHeight);
 
-        if (this.dragStartPoint && presetRatio) {
+        if (this.presetRatio) {
             const dx = x - right;
             const dy = y - bottom;
             const scaleTo = dx > dy ? 'width' : 'height';
@@ -609,7 +584,6 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
             ({width, height} = this.adjustRatioSize({
                 width,
                 height,
-                presetRatio,
                 scaleTo,
                 maxWidth,
                 maxHeight
@@ -634,7 +608,6 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
      */
     _resizeMB({y}) {
         const {width: maxX, height: maxY} = this.canvas;
-        const {presetRatio} = this.options;
         const rect = this.getBoundingRect(false, true);
 
         const maxWidth = maxX - rect.left;
@@ -644,11 +617,10 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
         let {width} = rect;
         let height = clamp(y - rect.top, minHeight, maxHeight);
 
-        if (this.dragStartPoint && presetRatio) {
+        if (this.presetRatio) {
             ({width, height} = this.adjustRatioSize({
                 width,
                 height,
-                presetRatio,
                 scaleTo: 'height',
                 maxWidth,
                 maxHeight
@@ -673,7 +645,6 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
      */
     _resizeML({x}) {
         const {height: maxY} = this.canvas;
-        const {presetRatio} = this.options;
         const rect = this.getBoundingRect(false, true);
 
         const right = rect.width + rect.left;
@@ -685,11 +656,10 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
         let width = clamp(right - x, minWidth, maxWidth);
         let {height} = rect;
 
-        if (presetRatio) {
+        if (this.presetRatio) {
             ({width, height} = this.adjustRatioSize({
                 width,
                 height,
-                presetRatio,
                 scaleTo: 'width',
                 maxWidth,
                 maxHeight
@@ -716,7 +686,6 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
      */
     _resizeMR({x}) {
         const {width: maxX, height: maxY} = this.canvas;
-        const {presetRatio} = this.options;
         const rect = this.getBoundingRect(false, true);
 
         const maxWidth = maxX - rect.left;
@@ -726,11 +695,10 @@ const Cropzone = fabric.util.createClass(fabric.Rect, /** @lends Cropzone.protot
         let width = clamp(x - rect.left, minWidth, maxWidth);
         let {height} = rect;
 
-        if (presetRatio) {
+        if (this.presetRatio) {
             ({width, height} = this.adjustRatioSize({
                 width,
                 height,
-                presetRatio,
                 scaleTo: 'width',
                 maxWidth,
                 maxHeight

--- a/test/cropzone.spec.js
+++ b/test/cropzone.spec.js
@@ -2,6 +2,7 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhn.com>
  * @fileoverview Test cases of "src/js/extension/cropzone.js"
  */
+import snippet from 'tui-code-snippet';
 import fabric from 'fabric';
 import Cropzone from '../src/js/extension/cropzone';
 
@@ -76,162 +77,76 @@ describe('Cropzone', () => {
         expect(cropzone.isValid()).toBe(true);
     });
 
-    it('"_calcTopLeftScalingSizeFromPointer()"' +
-        ' should return scaling size(position + dimension)', () => {
+    it('"_resizeTL" should give the expected value at run', () => {
         const cropzone = new Cropzone(canvas, options, {});
-        let mousePointerX, mousePointerY,
-            expected, actual;
 
-        mousePointerX = 20;
-        mousePointerY = 30;
-        expected = {
-            left: 20,
-            top: 30,
-            width: 90,
-            height: 80
-        };
-        actual = cropzone._calcTopLeftScalingSizeFromPointer(mousePointerX, mousePointerY);
-        expect(actual).toEqual(expected);
-
-        mousePointerX = -10;
-        mousePointerY = 0;
-        expected = {
-            left: 0,
-            top: 0,
-            width: 110,
-            height: 110
-        };
-        actual = cropzone._calcTopLeftScalingSizeFromPointer(mousePointerX, mousePointerY);
-        expect(actual).toEqual(expected);
-
-        mousePointerX = 200;
-        mousePointerY = 300;
-        expected = {
-            left: 109,
-            top: 109,
-            width: 1,
-            height: 1
-        };
-        actual = cropzone._calcTopLeftScalingSizeFromPointer(mousePointerX, mousePointerY);
-        expect(actual).toEqual(expected);
+        expect(cropzone._resizeTL({
+            x: 30,
+            y: 40
+        })).toEqual({
+            left: 30,
+            top: 40,
+            width: 80,
+            height: 70
+        });
     });
 
-    it('"_calcBottomRightScalingSizeFromPointer()"' +
-        ' should return scaling size(dimension)', () => {
+    it('"_resizeTR" should give the expected value at run', () => {
         const cropzone = new Cropzone(canvas, options, {});
-        let mousePointerX, mousePointerY,
-            expected, actual;
 
-        // mocking canvas
-        cropzone.canvas = {
-            width: 400,
-            height: 400
-        };
-
-        mousePointerX = 20;
-        mousePointerY = 30;
-        expected = {
-            width: 10,
-            height: 20
-        };
-        actual = cropzone._calcBottomRightScalingSizeFromPointer(mousePointerX, mousePointerY);
-        expect(actual).toEqual(expected);
-
-        mousePointerX = -10;
-        mousePointerY = 0;
-        expected = {
-            width: 1,
-            height: 1
-        };
-        actual = cropzone._calcBottomRightScalingSizeFromPointer(mousePointerX, mousePointerY);
-        expect(actual).toEqual(expected);
-
-        mousePointerX = 200;
-        mousePointerY = 300;
-        expected = {
-            width: 190,
-            height: 290
-        };
-        actual = cropzone._calcBottomRightScalingSizeFromPointer(mousePointerX, mousePointerY);
-        expect(actual).toEqual(expected);
+        expect(cropzone._resizeTR({
+            x: 80,
+            y: 50
+        })).toEqual({
+            left: 10,
+            top: 50,
+            width: 70,
+            height: 60
+        });
     });
 
-    it('should be "cropzone" type', () => {
+    it('"_resizeBL" should give the expected value at run', () => {
         const cropzone = new Cropzone(canvas, options, {});
-        expect(cropzone.isType('cropzone')).toBe(true);
+
+        expect(cropzone._resizeBL({
+            x: 30,
+            y: 40
+        })).toEqual({
+            left: 30,
+            top: 10,
+            width: 80,
+            height: 30
+        });
     });
 
-    it('"_makeScalingSettings()" ' +
-        'should return suitable position&dimension values from corner', () => {
+    it('"_resizeBR" should give the expected value at run', () => {
         const cropzone = new Cropzone(canvas, options, {});
-        const mockTL = {
-                width: 1,
-                height: 2,
-                left: 3,
-                top: 4
-            },
-            mockBR = {
-                width: 5,
-                height: 6
-            };
-        let expected, actual;
 
-        expected = {
-            width: 1,
-            height: 2,
-            left: 3,
-            top: 4
-        };
-        actual = cropzone._makeScalingSettings(mockTL, mockBR, 'tl');
-        expect(expected).toEqual(actual);
+        expect(cropzone._resizeBR({
+            x: 30,
+            y: 40
+        })).toEqual({
+            left: 10,
+            top: 10,
+            width: 20,
+            height: 30
+        });
+    });
 
-        expected = {
-            width: 5,
-            height: 2,
-            top: 4
-        };
-        actual = cropzone._makeScalingSettings(mockTL, mockBR, 'tr');
-        expect(expected).toEqual(actual);
+    it('should yield the result of maintaining the ratio at running the resize function at a fixed rate', () => {
+        const presetRatio = 5 / 4;
+        const cropzone = new Cropzone(canvas, snippet.extend({}, options, {
+            width: 50,
+            height: 40,
+            presetRatio
+        }), {});
 
-        expected = {
-            width: 1,
-            height: 6,
-            left: 3
-        };
-        actual = cropzone._makeScalingSettings(mockTL, mockBR, 'bl');
-        expect(expected).toEqual(actual);
-
-        expected = {
-            width: 5,
-            height: 6
-        };
-        actual = cropzone._makeScalingSettings(mockTL, mockBR, 'br');
-        expect(expected).toEqual(actual);
-
-        expected = {
-            width: 1,
-            left: 3
-        };
-        actual = cropzone._makeScalingSettings(mockTL, mockBR, 'ml');
-        expect(expected).toEqual(actual);
-
-        expected = {
-            height: 2,
-            top: 4
-        };
-        actual = cropzone._makeScalingSettings(mockTL, mockBR, 'mt');
-        expect(expected).toEqual(actual);
-
-        expected = {
-            width: 5
-        };
-        actual = cropzone._makeScalingSettings(mockTL, mockBR, 'mr');
-        expect(expected).toEqual(actual);
-
-        expected = {
-            height: 6
-        };
-        actual = cropzone._makeScalingSettings(mockTL, mockBR, 'mb');
-        expect(expected).toEqual(actual);
+        snippet.forEach(['TL', 'TR', 'MT', 'ML', 'MR', 'MB', 'BL', 'BR'], conerType => {
+            const {width, height} = cropzone[`_resize${conerType}`]({
+                x: 20,
+                y: 20
+            });
+            expect(width / height).toEqual(presetRatio);
+        });
     });
 });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

#### issue

* https://github.com/nhn/tui.image-editor/issues/124
* 지정된 비율의 cropzone 을 선택한 경우에는 크롭존을 리사이즈 하는 경우 비율이 유지되며 리사이즈 되어야 함.
* ![스크린샷 2020-02-05 오전 11 10 43](https://user-images.githubusercontent.com/35218826/73804925-93831100-4808-11ea-98e2-5c19f6643f9a.png)



#### 작업내용
* 비율 고정시에는 드레그 마우스 포인터와 리사이즈 컨트롤 위치에 따른 리사이즈 비율의 너비 , 높이 기준점을 정하기 위해서 8개 방위의 리사이즈 컨트롤 별로 계산식이 존재 해야되기 때문에, 기존 방식을 버리고 더 접근하기 쉬운 방식으로 8개의 방위별로 각각 dimension을 구하는 방식으로 변경

    * 기존의 방식은 리사이즈의 기준점이 top-left corner 를 이용해 변경할때와, bottom-right corner를 변경할때의 두가지 관점에서만 dimension값을 판단한 값을 판단하여 8개의 각각 방위마다 조합하여 사용함.

