### PR TITLE
fix: image editor rotate bug (fix #340)

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -131,7 +131,7 @@ class Ui {
             this._setUiSize(uiSize);
         }
 
-        const {width, height} = this._getEditorDimension();
+        const {width, height} = this._getCanvasMaxDimension();
         const editorElementStyle = this._editorElement.style;
         const {menuBarPosition} = this.options;
 
@@ -600,16 +600,14 @@ class Ui {
     }
 
     /**
-     * Get editor dimension
+     * Get canvas max Dimension
      * @returns {Object} - width & height of editor
      * @private
      */
-    _getEditorDimension() {
-        const maxHeight = parseFloat(this._editorContainerElement.style.maxHeight);
-        const height = (this.imageSize.newHeight > maxHeight) ? maxHeight : this.imageSize.newHeight;
-
-        const maxWidth = parseFloat(this._editorContainerElement.style.maxWidth);
-        const width = (this.imageSize.newWidth > maxWidth) ? maxWidth : this.imageSize.newWidth;
+    _getCanvasMaxDimension() {
+        const {maxWidth, maxHeight} = this._editorContainerElement.style;
+        const width = parseFloat(maxWidth);
+        const height = parseFloat(maxHeight);
 
         return {
             width,
@@ -623,7 +621,7 @@ class Ui {
      * @private
      */
     _setEditorPosition(menuBarPosition) { // eslint-disable-line complexity
-        const {width, height} = this._getEditorDimension();
+        const {width, height} = this._getCanvasMaxDimension();
         const editorElementStyle = this._editorElement.style;
         let top = 0;
         let left = 0;

--- a/test/ui.spec.js
+++ b/test/ui.spec.js
@@ -141,7 +141,7 @@ describe('UI', () => {
     describe('_setEditorPosition()', () => {
         beforeEach(() => {
             ui._editorElement = document.createElement('div');
-            spyOn(ui, '_getEditorDimension').and.returnValue({
+            spyOn(ui, '_getCanvasMaxDimension').and.returnValue({
                 width: 300,
                 height: 300
             });


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

* https://github.com/nhn/tui.image-editor/issues/340

### 해결


착각으로 인해 잘못 구현된 _getEditorDimension을 제거하고 _getCanvasMaxDimension로 대체

이미지 크기가 .tui-image-editor 영역의 크기보다 클 경우 스크롤이 생기기 하고 싶어서 넣은 코드였으나, 알고보니 .tui-image-editor-wrap에서 스크롤이 생기고
.tui-image-editor는 scale된 실제 캔버스 크기과 같으면 되므로 잘못된 코드를 제거했습니다.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨