### PR TITLE
fix: group object delete after restore position (fix #356)

### DIFF
--- a/src/js/graphics.js
+++ b/src/js/graphics.js
@@ -315,11 +315,14 @@ class Graphics {
      */
     getActiveObjectIdForRemove() {
         const activeObject = this.getActiveObject();
-        const isSelection = activeObject.type === 'activeSelection';
+        const {type, left, top} = activeObject;
+        const isSelection = type === 'activeSelection';
 
         if (isSelection) {
-            const group = new fabric.Group();
-            group.add(...activeObject.getObjects());
+            const group = new fabric.Group([...activeObject.getObjects()], {
+                left,
+                top
+            });
 
             return this._addFabricObject(group);
         }

--- a/test/command.spec.js
+++ b/test/command.spec.js
@@ -404,8 +404,14 @@ describe('commandFactory', () => {
         let object, object2, group;
 
         beforeEach(() => {
-            object = new fabric.Rect();
-            object2 = new fabric.Rect();
+            object = new fabric.Rect({
+                left: 10,
+                top: 10
+            });
+            object2 = new fabric.Rect({
+                left: 5,
+                top: 20
+            });
             group = new fabric.Group();
 
             graphics.add(object);
@@ -447,6 +453,21 @@ describe('commandFactory', () => {
             )).then(() => {
                 expect(canvas.contains(object)).toBe(true);
                 expect(canvas.contains(object2)).toBe(true);
+                done();
+            });
+        });
+
+        it('"undo ()" should restore the position of the removed object (group). ', done => {
+            const activeSelection = graphics.getActiveSelectionFromObjects(canvas.getObjects());
+            graphics.setActiveObject(activeSelection);
+
+            invoker.execute(commands.REMOVE_OBJECT, graphics, graphics.getActiveObjectIdForRemove()).then(() => (
+                invoker.undo()
+            )).then(() => {
+                expect(object.left).toBe(10);
+                expect(object.top).toBe(10);
+                expect(object2.left).toBe(5);
+                expect(object2.top).toBe(20);
                 done();
             });
         });

--- a/test/graphics.spec.js
+++ b/test/graphics.spec.js
@@ -110,6 +110,28 @@ describe('Graphics', () => {
         expect(graphics.getObjects().length).toBe(0);
     });
 
+    it('Position of the group object to be deleted must be set to the last position before being removed.', () => {
+        const object = new fabric.Rect({
+            left: 10,
+            top: 10
+        });
+        const object2 = new fabric.Rect({
+            left: 5,
+            top: 20
+        });
+        canvas.add(object);
+        canvas.add(object2);
+
+        const activeSelection = graphics.getActiveSelectionFromObjects(canvas.getObjects());
+        graphics.setActiveObject(activeSelection);
+
+        const removeGroupObjectId = graphics.getActiveObjectIdForRemove();
+        const removeGroupObject = graphics.getObject(removeGroupObjectId);
+
+        expect(removeGroupObject.left).toBe(5);
+        expect(removeGroupObject.top).toBe(10);
+    });
+
     it('switches drawing modes', () => {
         let modeName;
         for (modeName in drawingModes) {

--- a/test/graphics.spec.js
+++ b/test/graphics.spec.js
@@ -110,28 +110,6 @@ describe('Graphics', () => {
         expect(graphics.getObjects().length).toBe(0);
     });
 
-    it('Position of the group object to be deleted must be set to the last position before being removed.', () => {
-        const object = new fabric.Rect({
-            left: 10,
-            top: 10
-        });
-        const object2 = new fabric.Rect({
-            left: 5,
-            top: 20
-        });
-        canvas.add(object);
-        canvas.add(object2);
-
-        const activeSelection = graphics.getActiveSelectionFromObjects(canvas.getObjects());
-        graphics.setActiveObject(activeSelection);
-
-        const removeGroupObjectId = graphics.getActiveObjectIdForRemove();
-        const removeGroupObject = graphics.getObject(removeGroupObjectId);
-
-        expect(removeGroupObject.left).toBe(5);
-        expect(removeGroupObject.top).toBe(10);
-    });
-
     it('switches drawing modes', () => {
         let modeName;
         for (modeName in drawingModes) {


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### 버그
다중 선택된 객체들을 백스페이스로 삭제 후 되돌리기(undo) 를 했을때 되돌려진 객체의 포지션이 정확하지 않음

### 버그원인
`graphics.getActiveObjectIdForRemove` 에서 멀티셀렉트된 객체들을 한번에 삭제하기위해 group을 만들어줄때 group의 포지션을 모름으로, 되돌릴때 x, y (0, 0)의 잘못된 포지션으로 되돌려줌

### 해결방법
삭제를 위한 group을 만들때 삭제되기 전의 오리지날 포지션을 정확히 넣어줌

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨