### PR TITLE
feat: add defaultText into includeUI options (refs #203)

### DIFF
--- a/src/js/action.js
+++ b/src/js/action.js
@@ -470,11 +470,11 @@ export default {
                     fontSize,
                     fontStyle,
                     fontWeight,
-                    underline
+                    underline,
+                    defaultText
                 } = this.ui.text;
                 const fontFamily = 'Noto Sans';
-
-                this.addText('Double Click', {
+                this.addText(defaultText, {
                     position: pos.originPosition,
                     styles: {fill, fontSize, fontFamily, fontStyle, fontWeight, underline}
                 }).then(() => {

--- a/src/js/imageEditor.js
+++ b/src/js/imageEditor.js
@@ -98,6 +98,7 @@ const {
  *      @param {string} options.includeUI.uiSize.width - width of ui
  *      @param {string} options.includeUI.uiSize.height - height of ui
  *    @param {string} [options.includeUI.menuBarPosition=bottom] - Menu bar position('top', 'bottom', 'left', 'right')
+ *    @param {string} [options.includeUI.defaultText="Double Click"] - Text used when adding new texts in the ui
  *  @param {number} options.cssMaxWidth - Canvas css-max-width
  *  @param {number} options.cssMaxHeight - Canvas css-max-height
  *  @param {Object} [options.selectionStyle] - selection style

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -191,7 +191,8 @@ class Ui {
                 width: '100%',
                 height: '100%'
             },
-            menuBarPosition: 'bottom'
+            menuBarPosition: 'bottom',
+            defaultText: 'Double Click'
         }, options);
     }
 
@@ -226,6 +227,7 @@ class Ui {
             this[menuName] = new SubComponentClass(this._subMenuElement, {
                 locale: this._locale,
                 makeSvgIcon: this.theme.makeMenSvgIconSet.bind(this.theme),
+                defaultText: this.options.defaultText,
                 menuBarPosition: this.options.menuBarPosition,
                 usageStatistics: this.options.usageStatistics
             });

--- a/src/js/ui/text.js
+++ b/src/js/ui/text.js
@@ -11,7 +11,7 @@ import {defaultTextRangeValus} from '../consts';
  * @ignore
  */
 export default class Text extends Submenu {
-    constructor(subMenuElement, {locale, makeSvgIcon, menuBarPosition, usageStatistics}) {
+    constructor(subMenuElement, {locale, defaultText, makeSvgIcon, menuBarPosition, usageStatistics}) {
         super(subMenuElement, {
             locale,
             name: 'text',
@@ -35,7 +35,8 @@ export default class Text extends Submenu {
             textRange: new Range({
                 slider: this.selector('.tie-text-range'),
                 input: this.selector('.tie-text-range-value')
-            }, defaultTextRangeValus)
+            }, defaultTextRangeValus),
+            defaultText
         };
     }
 
@@ -127,6 +128,22 @@ export default class Text extends Submenu {
     }
 
     /**
+     * Get default text
+     * @returns {string} - text size
+     */
+    get defaultText() {
+        return this._els.defaultText;
+    }
+
+    /**
+     * Set default text
+     * @param {Number} value - text size
+     */
+    set defaultText(value) {
+        this._els.defaultText = value;
+    }
+
+    /**
      * get font style
      * @returns {string} - font style
      */
@@ -151,10 +168,11 @@ export default class Text extends Submenu {
     }
 
     setTextStyleStateOnAction(textStyle = {}) {
-        const {fill, fontSize, fontStyle, fontWeight, textDecoration, textAlign} = textStyle;
+        const {fill, fontSize, fontStyle, fontWeight, textDecoration, textAlign, defaultText} = textStyle;
 
         this.textColor = fill;
         this.fontSize = fontSize;
+        this.defaultText = defaultText;
         this.setEffactState('italic', fontStyle);
         this.setEffactState('bold', fontWeight);
         this.setEffactState('underline', textDecoration);


### PR DESCRIPTION
I added a new option to the includeUI options:
```
includeUI: {
    ...
    defaultText: "DOUBLE CLICK ME"
},
```
It just sets the text used when a new text is added by the ui.
I did not add it as translation because i think its more a configuration for the ui than a translation.