### PR TITLE
Fix/text object position bug

### DIFF
--- a/src/js/component/text.js
+++ b/src/js/component/text.js
@@ -142,12 +142,7 @@ class Text extends Component {
         if (this.useItext) {
             canvas.forEachObject(obj => {
                 if (obj.type === 'i-text') {
-                    obj.set({
-                        left: obj.left - (obj.width / 2),
-                        top: obj.top - (obj.height / 2),
-                        originX: 'left',
-                        originY: 'top'
-                    });
+                    this.adjustOriginToPosition(obj, 'start');
                 }
             });
         } else {
@@ -172,12 +167,7 @@ class Text extends Component {
                     if (obj.text === '') {
                         canvas.remove(obj);
                     } else {
-                        obj.set({
-                            left: obj.left + (obj.width / 2),
-                            top: obj.top + (obj.height / 2),
-                            originX: 'center',
-                            originY: 'center'
-                        });
+                        this.adjustOriginToPosition(obj, 'end');
                     }
                 }
             });
@@ -193,6 +183,27 @@ class Text extends Component {
             'object:scaling': this._listeners.scaling,
             'text:editing': this._listeners.modify
         });
+    }
+
+    /**
+     * Adjust the origin position
+     * @param {fabric.Object} text - text object
+     * @param {string} editStatus - 'start' or 'end'
+     */
+    adjustOriginToPosition(text, editStatus) {
+        let [originX, originY] = ['center', 'center'];
+        if (editStatus === 'start') {
+            [originX, originY] = ['left', 'top'];
+        }
+
+        const {x: left, y: top} = text.getPointByOrigin(originX, originY);
+        text.set({
+            left,
+            top,
+            originX,
+            originY
+        });
+        text.setCoords();
     }
 
     /**

--- a/src/js/component/text.js
+++ b/src/js/component/text.js
@@ -142,7 +142,7 @@ class Text extends Component {
         if (this.useItext) {
             canvas.forEachObject(obj => {
                 if (obj.type === 'i-text') {
-                    this.adjustOriginToPosition(obj, 'start');
+                    this.adjustOriginPosition(obj, 'start');
                 }
             });
         } else {
@@ -167,7 +167,7 @@ class Text extends Component {
                     if (obj.text === '') {
                         canvas.remove(obj);
                     } else {
-                        this.adjustOriginToPosition(obj, 'end');
+                        this.adjustOriginPosition(obj, 'end');
                     }
                 }
             });
@@ -190,7 +190,7 @@ class Text extends Component {
      * @param {fabric.Object} text - text object
      * @param {string} editStatus - 'start' or 'end'
      */
-    adjustOriginToPosition(text, editStatus) {
+    adjustOriginPosition(text, editStatus) {
         let [originX, originY] = ['center', 'center'];
         if (editStatus === 'start') {
             [originX, originY] = ['left', 'top'];

--- a/test/text.spec.js
+++ b/test/text.spec.js
@@ -56,6 +56,28 @@ describe('Text', () => {
         });
     });
 
+    it('Rotated text elements must also maintain consistent left and top positions after entering and exiting drawing mode.', () => {
+        const left = 10;
+        const top = 20;
+        const newText = new fabric.IText('testString', {
+            left,
+            top,
+            width: 30,
+            height: 50,
+            angle: 40,
+            originX: 'center',
+            originY: 'center'
+        });
+        text.useItext = true;
+        canvas.add(newText);
+
+        text.start();
+        text.end();
+
+        expect(newText.left).toEqual(left);
+        expect(newText.top).toEqual(top);
+    });
+
     it('change() should change contents in the text object as input.', () => {
         text.add('text123', {});
 


### PR DESCRIPTION
<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

#401 

회전된 텍스트 객체의 포지션이 의도한 위치와 어긋나게 틀어짐

### 원인

텍스트 그리기 모드에서 빠져나갈때 origin을 center로 원복해줄때 회전을 고려하지 않고 left, top 포지션을 잡아줌

### 해결

객체의 width, height을 직접 계산하여 center 포지션을 맞춰주면 문제가 생기므로 fabric 에서 제공하는 api `getPointByOrigin`를 사용하여 포지션값을 직접 계산하지 않고 정확한 api에 맡겨서 해결 

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨