### PR TITLE
feat: default values for ui-tools (#258)

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -222,13 +222,16 @@ class Ui {
             // menu btn element
             this._buttonElements[menuName] = this._menuElement.querySelector(`.tie-btn-${menuName}`);
 
+            // options per menu item
+            const options = this.options[menuName] || {};
+
             // submenu ui instance
             this[menuName] = new SubComponentClass(this._subMenuElement, {
                 locale: this._locale,
                 makeSvgIcon: this.theme.makeMenSvgIconSet.bind(this.theme),
                 menuBarPosition: this.options.menuBarPosition,
                 usageStatistics: this.options.usageStatistics
-            });
+            }, options);
         });
     }
 

--- a/src/js/ui/draw.js
+++ b/src/js/ui/draw.js
@@ -4,6 +4,7 @@ import Range from './tools/range';
 import Submenu from './submenuBase';
 import templateHtml from './template/submenu/draw';
 import {defaultDrawRangeValus} from '../consts';
+import snippet from 'tui-code-snippet';
 const DRAW_OPACITY = 0.7;
 
 /**
@@ -12,7 +13,7 @@ const DRAW_OPACITY = 0.7;
  * @ignore
  */
 class Draw extends Submenu {
-    constructor(subMenuElement, {locale, makeSvgIcon, menuBarPosition, usageStatistics}) {
+    constructor(subMenuElement, {locale, makeSvgIcon, menuBarPosition, usageStatistics}, options) {
         super(subMenuElement, {
             locale,
             name: 'draw',
@@ -25,17 +26,18 @@ class Draw extends Submenu {
         this._els = {
             lineSelectButton: this.selector('.tie-draw-line-select-button'),
             drawColorPicker: new Colorpicker(
-                this.selector('.tie-draw-color'), '#00a9ff', this.toggleDirection, this.usageStatistics
+                this.selector('.tie-draw-color'), options.color || '#00a9ff', this.toggleDirection, this.usageStatistics
             ),
             drawRange: new Range({
                 slider: this.selector('.tie-draw-range'),
                 input: this.selector('.tie-draw-range-value')
-            }, defaultDrawRangeValus)
+            }, snippet.extend(defaultDrawRangeValus, options.range))
         };
 
         this.type = null;
         this.color = this._els.drawColorPicker.color;
         this.width = this._els.drawRange.value;
+        this.opacity = options.opacity || DRAW_OPACITY;
     }
 
     /**
@@ -79,7 +81,7 @@ class Draw extends Submenu {
     setDrawMode() {
         this.actions.setDrawMode(this.type, {
             width: this.width,
-            color: getRgb(this.color, DRAW_OPACITY)
+            color: getRgb(this.color, this.opacity)
         });
     }
 

--- a/src/js/ui/icon.js
+++ b/src/js/ui/icon.js
@@ -11,7 +11,7 @@ import {defaultIconPath} from '../consts';
  * @ignore
  */
 class Icon extends Submenu {
-    constructor(subMenuElement, {locale, makeSvgIcon, menuBarPosition, usageStatistics}) {
+    constructor(subMenuElement, {locale, makeSvgIcon, menuBarPosition, usageStatistics}, options) {
         super(subMenuElement, {
             locale,
             name: 'icon',
@@ -28,7 +28,7 @@ class Icon extends Submenu {
             registrIconButton: this.selector('.tie-icon-image-file'),
             addIconButton: this.selector('.tie-icon-add-button'),
             iconColorpicker: new Colorpicker(
-                this.selector('.tie-icon-color'), '#ffbb3b', this.toggleDirection, this.usageStatistics
+                this.selector('.tie-icon-color'), options.color || '#ffbb3b', this.toggleDirection, this.usageStatistics
             )
         };
     }

--- a/src/js/ui/shape.js
+++ b/src/js/ui/shape.js
@@ -4,6 +4,7 @@ import Submenu from './submenuBase';
 import templateHtml from './template/submenu/shape';
 import {toInteger, assignmentForDestroy} from '../util';
 import {defaultShapeStrokeValus} from '../consts';
+import snippet from 'tui-code-snippet';
 
 const SHAPE_DEFAULT_OPTION = {
     stroke: '#ffbb3b',
@@ -17,7 +18,7 @@ const SHAPE_DEFAULT_OPTION = {
  * @ignore
  */
 class Shape extends Submenu {
-    constructor(subMenuElement, {locale, makeSvgIcon, menuBarPosition, usageStatistics}) {
+    constructor(subMenuElement, {locale, makeSvgIcon, menuBarPosition, usageStatistics}, options) {
         super(subMenuElement, {
             locale,
             name: 'shape',
@@ -27,7 +28,7 @@ class Shape extends Submenu {
             usageStatistics
         });
         this.type = null;
-        this.options = SHAPE_DEFAULT_OPTION;
+        this.options = snippet.extend(SHAPE_DEFAULT_OPTION, options);
 
         this._els = {
             shapeSelectButton: this.selector('.tie-shape-button'),
@@ -40,7 +41,7 @@ class Shape extends Submenu {
                 this.selector('.tie-color-fill'), '', this.toggleDirection, this.usageStatistics
             ),
             strokeColorpicker: new Colorpicker(
-                this.selector('.tie-color-stroke'), '#ffbb3b', this.toggleDirection, this.usageStatistics
+                this.selector('.tie-color-stroke'), options.stroke || '#ffbb3b', this.toggleDirection, this.usageStatistics
             )
         };
 

--- a/src/js/ui/text.js
+++ b/src/js/ui/text.js
@@ -4,6 +4,7 @@ import Colorpicker from './tools/colorpicker';
 import Submenu from './submenuBase';
 import templateHtml from './template/submenu/text';
 import {defaultTextRangeValus} from '../consts';
+import snippet from 'tui-code-snippet';
 
 /**
  * Crop ui class
@@ -11,7 +12,7 @@ import {defaultTextRangeValus} from '../consts';
  * @ignore
  */
 export default class Text extends Submenu {
-    constructor(subMenuElement, {locale, makeSvgIcon, menuBarPosition, usageStatistics}) {
+    constructor(subMenuElement, {locale, makeSvgIcon, menuBarPosition, usageStatistics}, options) {
         super(subMenuElement, {
             locale,
             name: 'text',
@@ -30,12 +31,12 @@ export default class Text extends Submenu {
             textEffectButton: this.selector('.tie-text-effect-button'),
             textAlignButton: this.selector('.tie-text-align-button'),
             textColorpicker: new Colorpicker(
-                this.selector('.tie-text-color'), '#ffbb3b', this.toggleDirection, this.usageStatistics
+                this.selector('.tie-text-color'), options.color || '#ffbb3b', this.toggleDirection, this.usageStatistics
             ),
             textRange: new Range({
                 slider: this.selector('.tie-text-range'),
                 input: this.selector('.tie-text-range-value')
-            }, defaultTextRangeValus)
+            }, snippet.extend(defaultTextRangeValus, options.range))
         };
     }
 


### PR DESCRIPTION
override default values for "draw", "shape", "icon" and "text" when used with UI

<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨