### PR TITLE
feat: Added ability to allow developers to change colour palette preset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ test.html
 
 # Compiled files
 dist
+
+.vscode

--- a/src/js/imageEditor.js
+++ b/src/js/imageEditor.js
@@ -93,8 +93,8 @@ const {
  * @typedef {object} ShapeFillOption - fill option of shape
  * @property {string} type - fill type ('color' or 'filter')
  * @property {Array.<ShapeFillFilterOption>} [filter] - {@link ShapeFilterOption} List.
- *  only applies to filter types 
- *  (ex: \[\{pixelate: 20\}, \{blur: 0.3\}\]) 
+ *  only applies to filter types
+ *  (ex: \[\{pixelate: 20\}, \{blur: 0.3\}\])
  * @property {string} [color] - Shape foreground color (ex: '#fff', 'transparent')
  */
 
@@ -114,6 +114,7 @@ const {
  *      @param {string} options.includeUI.uiSize.width - width of ui
  *      @param {string} options.includeUI.uiSize.height - height of ui
  *    @param {string} [options.includeUI.menuBarPosition=bottom] - Menu bar position('top', 'bottom', 'left', 'right')
+ *    @param {string[]} [options.colorPalette=PICKER_COLOR] - Customize the default colour palette used by ImageEditor. Must be array of hexcodes
  *  @param {number} options.cssMaxWidth - Canvas css-max-width
  *  @param {number} options.cssMaxHeight - Canvas css-max-height
  *  @param {Object} [options.selectionStyle] - selection style
@@ -885,7 +886,7 @@ class ImageEditor {
      * Set states of current drawing shape
      * @param {string} type - Shape type (ex: 'rect', 'circle', 'triangle')
      * @param {Object} [options] - Shape options
-     *      @param {(ShapeFillOption | string)} [options.fill] - {@link ShapeFillOption} or 
+     *      @param {(ShapeFillOption | string)} [options.fill] - {@link ShapeFillOption} or
      *        Shape foreground color (ex: '#fff', 'transparent')
      *      @param {string} [options.stoke] - Shape outline color
      *      @param {number} [options.strokeWidth] - Shape outline width
@@ -938,7 +939,7 @@ class ImageEditor {
      * Add shape
      * @param {string} type - Shape type (ex: 'rect', 'circle', 'triangle')
      * @param {Object} options - Shape options
-     *      @param {(ShapeFillOption | string)} [options.fill] - {@link ShapeFillOption} or 
+     *      @param {(ShapeFillOption | string)} [options.fill] - {@link ShapeFillOption} or
      *        Shape foreground color (ex: '#fff', 'transparent')
      *      @param {string} [options.stroke] - Shape outline color
      *      @param {number} [options.strokeWidth] - Shape outline width
@@ -999,7 +1000,7 @@ class ImageEditor {
      * Change shape
      * @param {number} id - object id
      * @param {Object} options - Shape options
-     *      @param {(ShapeFillOption | string)} [options.fill] - {@link ShapeFillOption} or 
+     *      @param {(ShapeFillOption | string)} [options.fill] - {@link ShapeFillOption} or
      *        Shape foreground color (ex: '#fff', 'transparent')
      *      @param {string} [options.stroke] - Shape outline color
      *      @param {number} [options.strokeWidth] - Shape outline width

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -199,7 +199,7 @@ class Ui {
      * Set ui container size
      * @param {Object} uiSize - ui dimension
      *   @param {string} uiSize.width - css width property
-     *   @param {string} uiSize.height - css height property 
+     *   @param {string} uiSize.height - css height property
      * @private
      */
     _setUiSize(uiSize = this.options.uiSize) {
@@ -227,7 +227,8 @@ class Ui {
                 locale: this._locale,
                 makeSvgIcon: this.theme.makeMenSvgIconSet.bind(this.theme),
                 menuBarPosition: this.options.menuBarPosition,
-                usageStatistics: this.options.usageStatistics
+                usageStatistics: this.options.usageStatistics,
+                colorPalette: this.options.colorPalette
             });
         });
     }

--- a/src/js/ui/draw.js
+++ b/src/js/ui/draw.js
@@ -12,7 +12,7 @@ const DRAW_OPACITY = 0.7;
  * @ignore
  */
 class Draw extends Submenu {
-    constructor(subMenuElement, {locale, makeSvgIcon, menuBarPosition, usageStatistics}) {
+    constructor(subMenuElement, {locale, makeSvgIcon, menuBarPosition, usageStatistics, colorPalette}) {
         super(subMenuElement, {
             locale,
             name: 'draw',
@@ -25,7 +25,7 @@ class Draw extends Submenu {
         this._els = {
             lineSelectButton: this.selector('.tie-draw-line-select-button'),
             drawColorPicker: new Colorpicker(
-                this.selector('.tie-draw-color'), '#00a9ff', this.toggleDirection, this.usageStatistics
+                this.selector('.tie-draw-color'), '#00a9ff', this.toggleDirection, this.usageStatistics, colorPalette
             ),
             drawRange: new Range({
                 slider: this.selector('.tie-draw-range'),

--- a/src/js/ui/filter.js
+++ b/src/js/ui/filter.js
@@ -69,7 +69,7 @@ const COLORPICKER_INSTANCE_NAMES = [
  * @ignore
  */
 class Filter extends Submenu {
-    constructor(subMenuElement, {locale, menuBarPosition, usageStatistics}) {
+    constructor(subMenuElement, {locale, menuBarPosition, usageStatistics, colorPalette}) {
         super(subMenuElement, {
             locale,
             name: 'filter',
@@ -79,6 +79,7 @@ class Filter extends Submenu {
         });
 
         this.selectBoxShow = false;
+        this.colorPalette = colorPalette;
 
         this.checkedMap = {};
         this._makeControlElement();
@@ -326,13 +327,13 @@ class Filter extends Submenu {
                 FILTER_RANGE.colorfilterThresholeRange
             ),
             filterTintColor: new Colorpicker(
-                this.selector('.tie-filter-tint-color'), '#03bd9e', this.toggleDirection, this.usageStatistics
+                this.selector('.tie-filter-tint-color'), '#03bd9e', this.toggleDirection, this.usageStatistics, this.colorPalette
             ),
             filterMultiplyColor: new Colorpicker(
-                this.selector('.tie-filter-multiply-color'), '#515ce6', this.toggleDirection, this.usageStatistics
+                this.selector('.tie-filter-multiply-color'), '#515ce6', this.toggleDirection, this.usageStatistics, this.colorPalette
             ),
             filterBlendColor: new Colorpicker(
-                this.selector('.tie-filter-blend-color'), '#ffbb3b', this.toggleDirection, this.usageStatistics
+                this.selector('.tie-filter-blend-color'), '#ffbb3b', this.toggleDirection, this.usageStatistics, this.colorPalette
             )
         };
 

--- a/src/js/ui/icon.js
+++ b/src/js/ui/icon.js
@@ -11,7 +11,7 @@ import {defaultIconPath} from '../consts';
  * @ignore
  */
 class Icon extends Submenu {
-    constructor(subMenuElement, {locale, makeSvgIcon, menuBarPosition, usageStatistics}) {
+    constructor(subMenuElement, {locale, makeSvgIcon, menuBarPosition, usageStatistics, colorPalette}) {
         super(subMenuElement, {
             locale,
             name: 'icon',
@@ -28,7 +28,7 @@ class Icon extends Submenu {
             registrIconButton: this.selector('.tie-icon-image-file'),
             addIconButton: this.selector('.tie-icon-add-button'),
             iconColorpicker: new Colorpicker(
-                this.selector('.tie-icon-color'), '#ffbb3b', this.toggleDirection, this.usageStatistics
+                this.selector('.tie-icon-color'), '#ffbb3b', this.toggleDirection, this.usageStatistics, colorPalette
             )
         };
     }

--- a/src/js/ui/shape.js
+++ b/src/js/ui/shape.js
@@ -17,7 +17,7 @@ const SHAPE_DEFAULT_OPTION = {
  * @ignore
  */
 class Shape extends Submenu {
-    constructor(subMenuElement, {locale, makeSvgIcon, menuBarPosition, usageStatistics}) {
+    constructor(subMenuElement, {locale, makeSvgIcon, menuBarPosition, usageStatistics, colorPalette}) {
         super(subMenuElement, {
             locale,
             name: 'shape',
@@ -37,10 +37,10 @@ class Shape extends Submenu {
                 input: this.selector('.tie-stroke-range-value')
             }, defaultShapeStrokeValus),
             fillColorpicker: new Colorpicker(
-                this.selector('.tie-color-fill'), '', this.toggleDirection, this.usageStatistics
+                this.selector('.tie-color-fill'), '', this.toggleDirection, this.usageStatistics, colorPalette
             ),
             strokeColorpicker: new Colorpicker(
-                this.selector('.tie-color-stroke'), '#ffbb3b', this.toggleDirection, this.usageStatistics
+                this.selector('.tie-color-stroke'), '#ffbb3b', this.toggleDirection, this.usageStatistics, colorPalette
             )
         };
 

--- a/src/js/ui/text.js
+++ b/src/js/ui/text.js
@@ -11,7 +11,7 @@ import {defaultTextRangeValus} from '../consts';
  * @ignore
  */
 export default class Text extends Submenu {
-    constructor(subMenuElement, {locale, makeSvgIcon, menuBarPosition, usageStatistics}) {
+    constructor(subMenuElement, {locale, makeSvgIcon, menuBarPosition, usageStatistics, colorPalette}) {
         super(subMenuElement, {
             locale,
             name: 'text',
@@ -30,7 +30,7 @@ export default class Text extends Submenu {
             textEffectButton: this.selector('.tie-text-effect-button'),
             textAlignButton: this.selector('.tie-text-align-button'),
             textColorpicker: new Colorpicker(
-                this.selector('.tie-text-color'), '#ffbb3b', this.toggleDirection, this.usageStatistics
+                this.selector('.tie-text-color'), '#ffbb3b', this.toggleDirection, this.usageStatistics, colorPalette
             ),
             textRange: new Range({
                 slider: this.selector('.tie-text-range'),

--- a/src/js/ui/tools/colorpicker.js
+++ b/src/js/ui/tools/colorpicker.js
@@ -25,7 +25,7 @@ const PICKER_COLOR = [
  * @ignore
  */
 class Colorpicker {
-    constructor(colorpickerElement, defaultColor = '#7e7e7e', toggleDirection = 'up', usageStatistics) {
+    constructor(colorpickerElement, defaultColor = '#7e7e7e', toggleDirection = 'up', usageStatistics, colorPalette = PICKER_COLOR) {
         this.colorpickerElement = colorpickerElement;
         this.usageStatistics = usageStatistics;
 
@@ -38,7 +38,7 @@ class Colorpicker {
         this._color = defaultColor;
         this.picker = tuiColorPicker.create({
             container: this.pickerElement,
-            preset: PICKER_COLOR,
+            preset: colorPalette,
             color: defaultColor,
             usageStatistics: this.usageStatistics
         });


### PR DESCRIPTION
Added ability to allow developers to change colour palette preset
feat: Customize default colour palette (#481)

feat: #481

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description
Added ability to allow developers to change colour palette preset

When constructing the ImageEditor a developer can now pass through their own colour palette if they don't want to use the preset one.


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨