### PR TITLE
fix: not apply setBrush API when LINE_DRAWING [#409, #418]

### DIFF
--- a/src/js/graphics.js
+++ b/src/js/graphics.js
@@ -630,8 +630,8 @@ class Graphics {
         const drawingMode = this._drawingMode;
         let compName = components.FREE_DRAWING;
 
-        if (drawingMode === drawingModes.LINE) {
-            compName = drawingModes.LINE;
+        if (drawingMode === drawingModes.LINE_DRAWING) {
+            compName = components.LINE;
         }
 
         this.getComponent(compName).setBrush(option);


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description
Fix a bug that setBrush API did not work while line drawing


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨