### PR TITLE
correction in document URL in README of vue image editor

### DIFF
--- a/apps/vue-image-editor/README.md
+++ b/apps/vue-image-editor/README.md
@@ -118,7 +118,7 @@ export default {
 
 ### Props
 
-You can use `includeUi` and `options` props. Example of each props is in the [Getting Started](./docs/Basic-Tutorial.md).
+You can use `includeUi` and `options` props. Example of each props is in the [Getting Started](../../docs/Basic-Tutorial.md).
 
 - `includeUi`
 


### PR DESCRIPTION
There is an issue with hyperlinking in the README file of vue image editor app.
![issue](https://user-images.githubusercontent.com/41280839/108686071-ed8d6c00-751a-11eb-9b58-a47f4b7dbad8.png)

