### PR TITLE
fix CSP issue when build on production webpack

### DIFF
--- a/apps/image-editor/webpack.config.js
+++ b/apps/image-editor/webpack.config.js
@@ -131,4 +131,5 @@ module.exports = {
     host: '0.0.0.0',
     disableHostCheck: true,
   },
+  devtool: 'source-map'
 };


### PR DESCRIPTION
fix CSP issue when build on production webpack

fix: unsafe-eval by using devtool: source-map
  
https://github.com/nhn/toast-ui.react-image-editor/issues/30#issue-667395712

### Please check if the PR fulfills these requirements

- [ ] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change