### PR TITLE
fix: not remove key event listener when vue component loaded [#560]

### DIFF
--- a/apps/image-editor/src/js/component/zoom.js
+++ b/apps/image-editor/src/js/component/zoom.js
@@ -129,8 +129,22 @@ class Zoom extends Component {
     this.graphics.on(ADD_TEXT, this._startTextEditingHandler.bind(this));
     this.graphics.on(TEXT_EDITING, this._startTextEditingHandler.bind(this));
     this.graphics.on(OBJECT_MODIFIED, this._stopTextEditingHandler.bind(this));
+  }
+
+  /**
+   * Attach zoom keyboard events
+   */
+  attachKeyboardZoomEvents() {
     fabric.util.addListener(document, KEY_DOWN, this._listeners.keydown);
     fabric.util.addListener(document, KEY_UP, this._listeners.keyup);
+  }
+
+  /**
+   * Detach zoom keyboard events
+   */
+  detachKeyboardZoomEvents() {
+    fabric.util.removeListener(document, KEY_DOWN, this._listeners.keydown);
+    fabric.util.removeListener(document, KEY_UP, this._listeners.keyup);
   }
 
   /**

--- a/apps/image-editor/src/js/graphics.js
+++ b/apps/image-editor/src/js/graphics.js
@@ -162,6 +162,7 @@ class Graphics {
     this._createDrawingModeInstances();
     this._createComponents();
     this._attachCanvasEvents();
+    this._attachZoomEvents();
   }
 
   /**
@@ -173,6 +174,26 @@ class Graphics {
     this._canvas.clear();
 
     wrapperEl.parentNode.removeChild(wrapperEl);
+
+    this._detachZoomEvents();
+  }
+
+  /**
+   * Attach zoom events
+   */
+  _attachZoomEvents() {
+    const zoom = this.getComponent(components.ZOOM);
+
+    zoom.attachKeyboardZoomEvents();
+  }
+
+  /**
+   * Detach zoom events
+   */
+  _detachZoomEvents() {
+    const zoom = this.getComponent(components.ZOOM);
+
+    zoom.detachKeyboardZoomEvents();
   }
 
   /**


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements

- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

---

Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
