### PR TITLE
fix: removes the object when editing hex inputs of the color picker. (fix #504)

### DIFF
--- a/apps/image-editor/src/js/consts.js
+++ b/apps/image-editor/src/js/consts.js
@@ -169,6 +169,18 @@ export const eventNames = {
   HAND_STOPPED: 'handStopped',
   KEY_DOWN: 'keydown',
   KEY_UP: 'keyup',
+  INPUT_BOX_EDITING_STARTED: 'inputBoxEditingStarted',
+  INPUT_BOX_EDITING_STOPPED: 'inputBoxEditingStopped',
+  FOCUS: 'focus',
+  BLUR: 'blur',
+};
+
+/**
+ * Selector names
+ * @type {Object.<string, string>}
+ */
+export const selectorNames = {
+  COLOR_PICKER_INPUT_BOX: '.tui-colorpicker-palette-hex',
 };
 
 /**

--- a/apps/image-editor/src/js/imageEditor.js
+++ b/apps/image-editor/src/js/imageEditor.js
@@ -250,17 +250,17 @@ class ImageEditor {
   }
 
   _attachColorPickerInputBoxEvents() {
-    this.ui.on('inputBoxEditingStarted', () => {
+    this.ui.on(events.INPUT_BOX_EDITING_STARTED, () => {
       this.isColorPickerInputBoxEditing = true;
     });
-    this.ui.on('inputBoxEditingStopped', () => {
+    this.ui.on(events.INPUT_BOX_EDITING_STOPPED, () => {
       this.isColorPickerInputBoxEditing = false;
     });
   }
 
   _detachColorPickerInputBoxEvents() {
-    this.ui.off('inputBoxEditingStarted');
-    this.ui.off('inputBoxEditingStopped');
+    this.ui.off(events.INPUT_BOX_EDITING_STARTED);
+    this.ui.off(events.INPUT_BOX_EDITING_STOPPED);
   }
 
   /**

--- a/apps/image-editor/src/js/imageEditor.js
+++ b/apps/image-editor/src/js/imageEditor.js
@@ -244,8 +244,23 @@ class ImageEditor {
     if (this.ui) {
       this.ui.initCanvas();
       this.setReAction();
+      this._attachColorPickerInputBoxEvents();
     }
     fabric.enableGLFiltering = false;
+  }
+
+  _attachColorPickerInputBoxEvents() {
+    this.ui.on('inputBoxEditingStarted', () => {
+      this.isColorPickerInputBoxEditing = true;
+    });
+    this.ui.on('inputBoxEditingStopped', () => {
+      this.isColorPickerInputBoxEditing = false;
+    });
+  }
+
+  _detachColorPickerInputBoxEvents() {
+    this.ui.off('inputBoxEditingStarted');
+    this.ui.off('inputBoxEditingStopped');
   }
 
   /**
@@ -392,7 +407,7 @@ class ImageEditor {
     const isDeleteKey = keyCode === keyCodes.BACKSPACE || keyCode === keyCodes.DEL;
     const isRemoveReady = this._graphics.isReadyRemoveObject();
 
-    if (isRemoveReady && isDeleteKey) {
+    if (!this.isColorPickerInputBoxEditing && isRemoveReady && isDeleteKey) {
       e.preventDefault();
       this.removeActiveObject();
     }
@@ -1574,6 +1589,7 @@ class ImageEditor {
     this._graphics = null;
 
     if (this.ui) {
+      this._detachColorPickerInputBoxEvents();
       this.ui.destroy();
     }
 

--- a/apps/image-editor/src/js/ui.js
+++ b/apps/image-editor/src/js/ui.js
@@ -602,6 +602,8 @@ class Ui {
    */
   _addSubMenuEvent(menuName) {
     this[menuName].addEvent(this._actions[menuName]);
+    this[menuName].on('inputBoxEditingStarted', () => this.fire('inputBoxEditingStarted'));
+    this[menuName].on('inputBoxEditingStopped', () => this.fire('inputBoxEditingStopped'));
   }
 
   /**
@@ -622,6 +624,8 @@ class Ui {
   _removeMainMenuEvent() {
     snippet.forEach(this.options.menu, (menuName) => {
       this._buttonElements[menuName].removeEventListener('click', this.eventHandler[menuName]);
+      this[menuName].off('inputBoxEditingStarted');
+      this[menuName].off('inputBoxEditingStopped');
     });
   }
 

--- a/apps/image-editor/src/js/ui.js
+++ b/apps/image-editor/src/js/ui.js
@@ -602,8 +602,12 @@ class Ui {
    */
   _addSubMenuEvent(menuName) {
     this[menuName].addEvent(this._actions[menuName]);
-    this[menuName].on('inputBoxEditingStarted', () => this.fire('inputBoxEditingStarted'));
-    this[menuName].on('inputBoxEditingStopped', () => this.fire('inputBoxEditingStopped'));
+    this[menuName].on(eventNames.INPUT_BOX_EDITING_STARTED, () =>
+      this.fire(eventNames.INPUT_BOX_EDITING_STARTED)
+    );
+    this[menuName].on(eventNames.INPUT_BOX_EDITING_STOPPED, () =>
+      this.fire(eventNames.INPUT_BOX_EDITING_STOPPED)
+    );
   }
 
   /**
@@ -624,8 +628,8 @@ class Ui {
   _removeMainMenuEvent() {
     snippet.forEach(this.options.menu, (menuName) => {
       this._buttonElements[menuName].removeEventListener('click', this.eventHandler[menuName]);
-      this[menuName].off('inputBoxEditingStarted');
-      this[menuName].off('inputBoxEditingStopped');
+      this[menuName].off(eventNames.INPUT_BOX_EDITING_STARTED);
+      this[menuName].off(eventNames.INPUT_BOX_EDITING_STOPPED);
     });
   }
 

--- a/apps/image-editor/src/js/ui/draw.js
+++ b/apps/image-editor/src/js/ui/draw.js
@@ -1,3 +1,4 @@
+import { CustomEvents } from 'tui-code-snippet';
 import Colorpicker from '@/ui/tools/colorpicker';
 import Range from '@/ui/tools/range';
 import Submenu from '@/ui/submenuBase';
@@ -43,6 +44,10 @@ class Draw extends Submenu {
     this.type = null;
     this.color = this._els.drawColorPicker.color;
     this.width = this._els.drawRange.value;
+
+    this.colorPickerInputBox = this._els.drawColorPicker.colorpickerElement.querySelector(
+      '.tui-colorpicker-palette-hex'
+    );
   }
 
   /**
@@ -68,6 +73,9 @@ class Draw extends Submenu {
     this._els.lineSelectButton.addEventListener('click', this.eventHandler.changeDrawType);
     this._els.drawColorPicker.on('change', this._changeDrawColor.bind(this));
     this._els.drawRange.on('change', this._changeDrawRange.bind(this));
+
+    this.colorPickerInputBox.addEventListener('focus', this._onStartEditingInputBox.bind(this));
+    this.colorPickerInputBox.addEventListener('blur', this._onStopEditingInputBox.bind(this));
   }
 
   /**
@@ -78,6 +86,9 @@ class Draw extends Submenu {
     this._els.lineSelectButton.removeEventListener('click', this.eventHandler.changeDrawType);
     this._els.drawColorPicker.off();
     this._els.drawRange.off();
+
+    this.colorPickerInputBox.removeEventListener('focus', this._onStartEditingInputBox.bind(this));
+    this.colorPickerInputBox.removeEventListener('blur', this._onStopEditingInputBox.bind(this));
   }
 
   /**
@@ -162,5 +173,7 @@ class Draw extends Submenu {
     }
   }
 }
+
+CustomEvents.mixin(Draw);
 
 export default Draw;

--- a/apps/image-editor/src/js/ui/draw.js
+++ b/apps/image-editor/src/js/ui/draw.js
@@ -3,7 +3,7 @@ import Range from '@/ui/tools/range';
 import Submenu from '@/ui/submenuBase';
 import templateHtml from '@/ui/template/submenu/draw';
 import { assignmentForDestroy, getRgb } from '@/util';
-import { defaultDrawRangeValues } from '@/consts';
+import { defaultDrawRangeValues, eventNames, selectorNames } from '@/consts';
 
 const DRAW_OPACITY = 0.7;
 
@@ -45,7 +45,7 @@ class Draw extends Submenu {
     this.width = this._els.drawRange.value;
 
     this.colorPickerInputBox = this._els.drawColorPicker.colorpickerElement.querySelector(
-      '.tui-colorpicker-palette-hex'
+      selectorNames.COLOR_PICKER_INPUT_BOX
     );
   }
 
@@ -73,8 +73,14 @@ class Draw extends Submenu {
     this._els.drawColorPicker.on('change', this._changeDrawColor.bind(this));
     this._els.drawRange.on('change', this._changeDrawRange.bind(this));
 
-    this.colorPickerInputBox.addEventListener('focus', this._onStartEditingInputBox.bind(this));
-    this.colorPickerInputBox.addEventListener('blur', this._onStopEditingInputBox.bind(this));
+    this.colorPickerInputBox.addEventListener(
+      eventNames.FOCUS,
+      this._onStartEditingInputBox.bind(this)
+    );
+    this.colorPickerInputBox.addEventListener(
+      eventNames.BLUR,
+      this._onStopEditingInputBox.bind(this)
+    );
   }
 
   /**
@@ -86,8 +92,14 @@ class Draw extends Submenu {
     this._els.drawColorPicker.off();
     this._els.drawRange.off();
 
-    this.colorPickerInputBox.removeEventListener('focus', this._onStartEditingInputBox.bind(this));
-    this.colorPickerInputBox.removeEventListener('blur', this._onStopEditingInputBox.bind(this));
+    this.colorPickerInputBox.removeEventListener(
+      eventNames.FOCUS,
+      this._onStartEditingInputBox.bind(this)
+    );
+    this.colorPickerInputBox.removeEventListener(
+      eventNames.BLUR,
+      this._onStopEditingInputBox.bind(this)
+    );
   }
 
   /**

--- a/apps/image-editor/src/js/ui/draw.js
+++ b/apps/image-editor/src/js/ui/draw.js
@@ -1,4 +1,3 @@
-import { CustomEvents } from 'tui-code-snippet';
 import Colorpicker from '@/ui/tools/colorpicker';
 import Range from '@/ui/tools/range';
 import Submenu from '@/ui/submenuBase';
@@ -173,7 +172,5 @@ class Draw extends Submenu {
     }
   }
 }
-
-CustomEvents.mixin(Draw);
 
 export default Draw;

--- a/apps/image-editor/src/js/ui/filter.js
+++ b/apps/image-editor/src/js/ui/filter.js
@@ -4,7 +4,7 @@ import Range from '@/ui/tools/range';
 import Submenu from '@/ui/submenuBase';
 import templateHtml from '@/ui/template/submenu/filter';
 import { toInteger, toCamelCase, assignmentForDestroy } from '@/util';
-import { defaultFilterRangeValues as FILTER_RANGE } from '@/consts';
+import { defaultFilterRangeValues as FILTER_RANGE, eventNames, selectorNames } from '@/consts';
 
 const PICKER_CONTROL_HEIGHT = '130px';
 const BLEND_OPTIONS = ['add', 'diff', 'subtract', 'multiply', 'screen', 'lighten', 'darken'];
@@ -109,8 +109,8 @@ class Filter extends Submenu {
     snippet.forEachArray(
       this.colorPickerInputBoxes,
       (inputBox) => {
-        inputBox.removeEventListener('focus', this._onStartEditingInputBox.bind(this));
-        inputBox.removeEventListener('blur', this._onStopEditingInputBox.bind(this));
+        inputBox.removeEventListener(eventNames.FOCUS, this._onStartEditingInputBox.bind(this));
+        inputBox.removeEventListener(eventNames.BLUR, this._onStopEditingInputBox.bind(this));
       },
       this
     );
@@ -167,8 +167,8 @@ class Filter extends Submenu {
     snippet.forEachArray(
       this.colorPickerInputBoxes,
       (inputBox) => {
-        inputBox.addEventListener('focus', this._onStartEditingInputBox.bind(this));
-        inputBox.addEventListener('blur', this._onStopEditingInputBox.bind(this));
+        inputBox.addEventListener(eventNames.FOCUS, this._onStartEditingInputBox.bind(this));
+        inputBox.addEventListener(eventNames.BLUR, this._onStopEditingInputBox.bind(this));
       },
       this
     );
@@ -370,13 +370,19 @@ class Filter extends Submenu {
 
     this.colorPickerInputBoxes = [];
     this.colorPickerInputBoxes.push(
-      this._els.filterTintColor.colorpickerElement.querySelector('.tui-colorpicker-palette-hex')
+      this._els.filterTintColor.colorpickerElement.querySelector(
+        selectorNames.COLOR_PICKER_INPUT_BOX
+      )
     );
     this.colorPickerInputBoxes.push(
-      this._els.filterMultiplyColor.colorpickerElement.querySelector('.tui-colorpicker-palette-hex')
+      this._els.filterMultiplyColor.colorpickerElement.querySelector(
+        selectorNames.COLOR_PICKER_INPUT_BOX
+      )
     );
     this.colorPickerInputBoxes.push(
-      this._els.filterBlendColor.colorpickerElement.querySelector('.tui-colorpicker-palette-hex')
+      this._els.filterBlendColor.colorpickerElement.querySelector(
+        selectorNames.COLOR_PICKER_INPUT_BOX
+      )
     );
   }
 

--- a/apps/image-editor/src/js/ui/filter.js
+++ b/apps/image-editor/src/js/ui/filter.js
@@ -489,6 +489,4 @@ class Filter extends Submenu {
   }
 }
 
-snippet.CustomEvents.mixin(Filter);
-
 export default Filter;

--- a/apps/image-editor/src/js/ui/filter.js
+++ b/apps/image-editor/src/js/ui/filter.js
@@ -105,6 +105,15 @@ class Filter extends Submenu {
 
     this._els.blendType.removeEventListener('change', this.eventHandler.changeBlendFilter);
     this._els.blendType.removeEventListener('click', this.eventHandler.changeBlendFilter);
+
+    snippet.forEachArray(
+      this.colorPickerInputBoxes,
+      (inputBox) => {
+        inputBox.removeEventListener('focus', this._onStartEditingInputBox.bind(this));
+        inputBox.removeEventListener('blur', this._onStopEditingInputBox.bind(this));
+      },
+      this
+    );
   }
 
   _destroyToolInstance() {
@@ -154,6 +163,15 @@ class Filter extends Submenu {
 
     this._els.blendType.addEventListener('change', this.eventHandler.changeBlendFilter);
     this._els.blendType.addEventListener('click', this.eventHandler.blandTypeClick);
+
+    snippet.forEachArray(
+      this.colorPickerInputBoxes,
+      (inputBox) => {
+        inputBox.addEventListener('focus', this._onStartEditingInputBox.bind(this));
+        inputBox.addEventListener('blur', this._onStopEditingInputBox.bind(this));
+      },
+      this
+    );
   }
 
   /**
@@ -349,6 +367,17 @@ class Filter extends Submenu {
     this.colorPickerControls.push(this._els.filterTintColor);
     this.colorPickerControls.push(this._els.filterMultiplyColor);
     this.colorPickerControls.push(this._els.filterBlendColor);
+
+    this.colorPickerInputBoxes = [];
+    this.colorPickerInputBoxes.push(
+      this._els.filterTintColor.colorpickerElement.querySelector('.tui-colorpicker-palette-hex')
+    );
+    this.colorPickerInputBoxes.push(
+      this._els.filterMultiplyColor.colorpickerElement.querySelector('.tui-colorpicker-palette-hex')
+    );
+    this.colorPickerInputBoxes.push(
+      this._els.filterBlendColor.colorpickerElement.querySelector('.tui-colorpicker-palette-hex')
+    );
   }
 
   /**
@@ -459,5 +488,7 @@ class Filter extends Submenu {
     });
   }
 }
+
+snippet.CustomEvents.mixin(Filter);
 
 export default Filter;

--- a/apps/image-editor/src/js/ui/icon.js
+++ b/apps/image-editor/src/js/ui/icon.js
@@ -34,6 +34,10 @@ class Icon extends Submenu {
         this.usageStatistics
       ),
     };
+
+    this.colorPickerInputBox = this._els.iconColorpicker.colorpickerElement.querySelector(
+      '.tui-colorpicker-palette-hex'
+    );
   }
 
   /**
@@ -66,6 +70,9 @@ class Icon extends Submenu {
     this._els.iconColorpicker.on('change', this._changeColorHandler.bind(this));
     this._els.registerIconButton.addEventListener('change', registerIcon);
     this._els.addIconButton.addEventListener('click', addIcon);
+
+    this.colorPickerInputBox.addEventListener('focus', this._onStartEditingInputBox.bind(this));
+    this.colorPickerInputBox.addEventListener('blur', this._onStopEditingInputBox.bind(this));
   }
 
   /**
@@ -76,6 +83,9 @@ class Icon extends Submenu {
     this._els.iconColorpicker.off();
     this._els.registerIconButton.removeEventListener('change', this.eventHandler.registerIcon);
     this._els.addIconButton.removeEventListener('click', this.eventHandler.addIcon);
+
+    this.colorPickerInputBox.removeEventListener('focus', this._onStartEditingInputBox.bind(this));
+    this.colorPickerInputBox.removeEventListener('blur', this._onStopEditingInputBox.bind(this));
   }
 
   /**
@@ -166,5 +176,7 @@ class Icon extends Submenu {
     }
   }
 }
+
+snippet.CustomEvents.mixin(Icon);
 
 export default Icon;

--- a/apps/image-editor/src/js/ui/icon.js
+++ b/apps/image-editor/src/js/ui/icon.js
@@ -3,7 +3,7 @@ import Colorpicker from '@/ui/tools/colorpicker';
 import Submenu from '@/ui/submenuBase';
 import templateHtml from '@/ui/template/submenu/icon';
 import { isSupportFileApi, assignmentForDestroy } from '@/util';
-import { defaultIconPath } from '@/consts';
+import { defaultIconPath, eventNames, selectorNames } from '@/consts';
 
 /**
  * Icon ui class
@@ -36,7 +36,7 @@ class Icon extends Submenu {
     };
 
     this.colorPickerInputBox = this._els.iconColorpicker.colorpickerElement.querySelector(
-      '.tui-colorpicker-palette-hex'
+      selectorNames.COLOR_PICKER_INPUT_BOX
     );
   }
 
@@ -71,8 +71,14 @@ class Icon extends Submenu {
     this._els.registerIconButton.addEventListener('change', registerIcon);
     this._els.addIconButton.addEventListener('click', addIcon);
 
-    this.colorPickerInputBox.addEventListener('focus', this._onStartEditingInputBox.bind(this));
-    this.colorPickerInputBox.addEventListener('blur', this._onStopEditingInputBox.bind(this));
+    this.colorPickerInputBox.addEventListener(
+      eventNames.FOCUS,
+      this._onStartEditingInputBox.bind(this)
+    );
+    this.colorPickerInputBox.addEventListener(
+      eventNames.BLUR,
+      this._onStopEditingInputBox.bind(this)
+    );
   }
 
   /**
@@ -84,8 +90,14 @@ class Icon extends Submenu {
     this._els.registerIconButton.removeEventListener('change', this.eventHandler.registerIcon);
     this._els.addIconButton.removeEventListener('click', this.eventHandler.addIcon);
 
-    this.colorPickerInputBox.removeEventListener('focus', this._onStartEditingInputBox.bind(this));
-    this.colorPickerInputBox.removeEventListener('blur', this._onStopEditingInputBox.bind(this));
+    this.colorPickerInputBox.removeEventListener(
+      eventNames.FOCUS,
+      this._onStartEditingInputBox.bind(this)
+    );
+    this.colorPickerInputBox.removeEventListener(
+      eventNames.BLUR,
+      this._onStopEditingInputBox.bind(this)
+    );
   }
 
   /**

--- a/apps/image-editor/src/js/ui/icon.js
+++ b/apps/image-editor/src/js/ui/icon.js
@@ -177,6 +177,4 @@ class Icon extends Submenu {
   }
 }
 
-snippet.CustomEvents.mixin(Icon);
-
 export default Icon;

--- a/apps/image-editor/src/js/ui/shape.js
+++ b/apps/image-editor/src/js/ui/shape.js
@@ -1,3 +1,4 @@
+import snippet from 'tui-code-snippet';
 import Colorpicker from '@/ui/tools/colorpicker';
 import Range from '@/ui/tools/range';
 import Submenu from '@/ui/submenuBase';
@@ -55,6 +56,14 @@ class Shape extends Submenu {
 
     this.colorPickerControls.push(this._els.fillColorpicker);
     this.colorPickerControls.push(this._els.strokeColorpicker);
+
+    this.colorPickerInputBoxes = [];
+    this.colorPickerInputBoxes.push(
+      this._els.fillColorpicker.colorpickerElement.querySelector('.tui-colorpicker-palette-hex')
+    );
+    this.colorPickerInputBoxes.push(
+      this._els.strokeColorpicker.colorpickerElement.querySelector('.tui-colorpicker-palette-hex')
+    );
   }
 
   /**
@@ -85,6 +94,15 @@ class Shape extends Submenu {
     this._els.strokeColorpicker.on('change', this._changeStrokeColorHandler.bind(this));
     this._els.fillColorpicker.on('changeShow', this.colorPickerChangeShow.bind(this));
     this._els.strokeColorpicker.on('changeShow', this.colorPickerChangeShow.bind(this));
+
+    snippet.forEachArray(
+      this.colorPickerInputBoxes,
+      (inputBox) => {
+        inputBox.addEventListener('focus', this._onStartEditingInputBox.bind(this));
+        inputBox.addEventListener('blur', this._onStopEditingInputBox.bind(this));
+      },
+      this
+    );
   }
 
   /**
@@ -96,6 +114,15 @@ class Shape extends Submenu {
     this._els.strokeRange.off();
     this._els.fillColorpicker.off();
     this._els.strokeColorpicker.off();
+
+    snippet.forEachArray(
+      this.colorPickerInputBoxes,
+      (inputBox) => {
+        inputBox.removeEventListener('focus', this._onStartEditingInputBox.bind(this));
+        inputBox.removeEventListener('blur', this._onStopEditingInputBox.bind(this));
+      },
+      this
+    );
   }
 
   /**
@@ -232,5 +259,7 @@ class Shape extends Submenu {
     });
   }
 }
+
+snippet.CustomEvents.mixin(Shape);
 
 export default Shape;

--- a/apps/image-editor/src/js/ui/shape.js
+++ b/apps/image-editor/src/js/ui/shape.js
@@ -260,6 +260,4 @@ class Shape extends Submenu {
   }
 }
 
-snippet.CustomEvents.mixin(Shape);
-
 export default Shape;

--- a/apps/image-editor/src/js/ui/shape.js
+++ b/apps/image-editor/src/js/ui/shape.js
@@ -4,7 +4,7 @@ import Range from '@/ui/tools/range';
 import Submenu from '@/ui/submenuBase';
 import templateHtml from '@/ui/template/submenu/shape';
 import { toInteger, assignmentForDestroy } from '@/util';
-import { defaultShapeStrokeValues } from '@/consts';
+import { defaultShapeStrokeValues, eventNames, selectorNames } from '@/consts';
 
 const SHAPE_DEFAULT_OPTION = {
   stroke: '#ffbb3b',
@@ -59,10 +59,14 @@ class Shape extends Submenu {
 
     this.colorPickerInputBoxes = [];
     this.colorPickerInputBoxes.push(
-      this._els.fillColorpicker.colorpickerElement.querySelector('.tui-colorpicker-palette-hex')
+      this._els.fillColorpicker.colorpickerElement.querySelector(
+        selectorNames.COLOR_PICKER_INPUT_BOX
+      )
     );
     this.colorPickerInputBoxes.push(
-      this._els.strokeColorpicker.colorpickerElement.querySelector('.tui-colorpicker-palette-hex')
+      this._els.strokeColorpicker.colorpickerElement.querySelector(
+        selectorNames.COLOR_PICKER_INPUT_BOX
+      )
     );
   }
 
@@ -98,8 +102,8 @@ class Shape extends Submenu {
     snippet.forEachArray(
       this.colorPickerInputBoxes,
       (inputBox) => {
-        inputBox.addEventListener('focus', this._onStartEditingInputBox.bind(this));
-        inputBox.addEventListener('blur', this._onStopEditingInputBox.bind(this));
+        inputBox.addEventListener(eventNames.FOCUS, this._onStartEditingInputBox.bind(this));
+        inputBox.addEventListener(eventNames.BLUR, this._onStopEditingInputBox.bind(this));
       },
       this
     );
@@ -118,8 +122,8 @@ class Shape extends Submenu {
     snippet.forEachArray(
       this.colorPickerInputBoxes,
       (inputBox) => {
-        inputBox.removeEventListener('focus', this._onStartEditingInputBox.bind(this));
-        inputBox.removeEventListener('blur', this._onStopEditingInputBox.bind(this));
+        inputBox.removeEventListener(eventNames.FOCUS, this._onStartEditingInputBox.bind(this));
+        inputBox.removeEventListener(eventNames.BLUR, this._onStopEditingInputBox.bind(this));
       },
       this
     );

--- a/apps/image-editor/src/js/ui/submenuBase.js
+++ b/apps/image-editor/src/js/ui/submenuBase.js
@@ -104,6 +104,14 @@ class Submenu {
 
     this.subMenuElement.appendChild(iconSubMenu);
   }
+
+  _onStartEditingInputBox() {
+    this.fire('inputBoxEditingStarted');
+  }
+
+  _onStopEditingInputBox() {
+    this.fire('inputBoxEditingStopped');
+  }
 }
 
 export default Submenu;

--- a/apps/image-editor/src/js/ui/submenuBase.js
+++ b/apps/image-editor/src/js/ui/submenuBase.js
@@ -1,3 +1,5 @@
+import { CustomEvents } from 'tui-code-snippet';
+
 /**
  * Submenu Base Class
  * @class
@@ -113,5 +115,7 @@ class Submenu {
     this.fire('inputBoxEditingStopped');
   }
 }
+
+CustomEvents.mixin(Submenu);
 
 export default Submenu;

--- a/apps/image-editor/src/js/ui/submenuBase.js
+++ b/apps/image-editor/src/js/ui/submenuBase.js
@@ -1,4 +1,5 @@
 import { CustomEvents } from 'tui-code-snippet';
+import { eventNames } from '@/consts';
 
 /**
  * Submenu Base Class
@@ -108,11 +109,11 @@ class Submenu {
   }
 
   _onStartEditingInputBox() {
-    this.fire('inputBoxEditingStarted');
+    this.fire(eventNames.INPUT_BOX_EDITING_STARTED);
   }
 
   _onStopEditingInputBox() {
-    this.fire('inputBoxEditingStopped');
+    this.fire(eventNames.INPUT_BOX_EDITING_STOPPED);
   }
 }
 

--- a/apps/image-editor/src/js/ui/text.js
+++ b/apps/image-editor/src/js/ui/text.js
@@ -1,3 +1,4 @@
+import { CustomEvents } from 'tui-code-snippet';
 import Range from '@/ui/tools/range';
 import Colorpicker from '@/ui/tools/colorpicker';
 import Submenu from '@/ui/submenuBase';
@@ -10,7 +11,7 @@ import { defaultTextRangeValues } from '@/consts';
  * @class
  * @ignore
  */
-export default class Text extends Submenu {
+class Text extends Submenu {
   constructor(subMenuElement, { locale, makeSvgIcon, menuBarPosition, usageStatistics }) {
     super(subMenuElement, {
       locale,
@@ -43,6 +44,10 @@ export default class Text extends Submenu {
         defaultTextRangeValues
       ),
     };
+
+    this.colorPickerInputBox = this._els.textColorpicker.colorpickerElement.querySelector(
+      '.tui-colorpicker-palette-hex'
+    );
   }
 
   /**
@@ -75,6 +80,9 @@ export default class Text extends Submenu {
     this._els.textAlignButton.addEventListener('click', setTextAlign);
     this._els.textRange.on('change', this._changeTextRnageHandler.bind(this));
     this._els.textColorpicker.on('change', this._changeColorHandler.bind(this));
+
+    this.colorPickerInputBox.addEventListener('focus', this._onStartEditingInputBox.bind(this));
+    this.colorPickerInputBox.addEventListener('blur', this._onStopEditingInputBox.bind(this));
   }
 
   /**
@@ -88,6 +96,9 @@ export default class Text extends Submenu {
     this._els.textAlignButton.removeEventListener('click', setTextAlign);
     this._els.textRange.off();
     this._els.textColorpicker.off();
+
+    this.colorPickerInputBox.removeEventListener('focus', this._onStartEditingInputBox.bind(this));
+    this.colorPickerInputBox.removeEventListener('blur', this._onStopEditingInputBox.bind(this));
   }
 
   /**
@@ -253,3 +264,7 @@ export default class Text extends Submenu {
     });
   }
 }
+
+CustomEvents.mixin(Text);
+
+export default Text;

--- a/apps/image-editor/src/js/ui/text.js
+++ b/apps/image-editor/src/js/ui/text.js
@@ -1,4 +1,3 @@
-import { CustomEvents } from 'tui-code-snippet';
 import Range from '@/ui/tools/range';
 import Colorpicker from '@/ui/tools/colorpicker';
 import Submenu from '@/ui/submenuBase';
@@ -264,7 +263,5 @@ class Text extends Submenu {
     });
   }
 }
-
-CustomEvents.mixin(Text);
 
 export default Text;

--- a/apps/image-editor/src/js/ui/text.js
+++ b/apps/image-editor/src/js/ui/text.js
@@ -3,7 +3,7 @@ import Colorpicker from '@/ui/tools/colorpicker';
 import Submenu from '@/ui/submenuBase';
 import templateHtml from '@/ui/template/submenu/text';
 import { assignmentForDestroy } from '@/util';
-import { defaultTextRangeValues } from '@/consts';
+import { defaultTextRangeValues, eventNames, selectorNames } from '@/consts';
 
 /**
  * Crop ui class
@@ -45,7 +45,7 @@ class Text extends Submenu {
     };
 
     this.colorPickerInputBox = this._els.textColorpicker.colorpickerElement.querySelector(
-      '.tui-colorpicker-palette-hex'
+      selectorNames.COLOR_PICKER_INPUT_BOX
     );
   }
 
@@ -80,8 +80,14 @@ class Text extends Submenu {
     this._els.textRange.on('change', this._changeTextRnageHandler.bind(this));
     this._els.textColorpicker.on('change', this._changeColorHandler.bind(this));
 
-    this.colorPickerInputBox.addEventListener('focus', this._onStartEditingInputBox.bind(this));
-    this.colorPickerInputBox.addEventListener('blur', this._onStopEditingInputBox.bind(this));
+    this.colorPickerInputBox.addEventListener(
+      eventNames.FOCUS,
+      this._onStartEditingInputBox.bind(this)
+    );
+    this.colorPickerInputBox.addEventListener(
+      eventNames.BLUR,
+      this._onStopEditingInputBox.bind(this)
+    );
   }
 
   /**
@@ -96,8 +102,14 @@ class Text extends Submenu {
     this._els.textRange.off();
     this._els.textColorpicker.off();
 
-    this.colorPickerInputBox.removeEventListener('focus', this._onStartEditingInputBox.bind(this));
-    this.colorPickerInputBox.removeEventListener('blur', this._onStopEditingInputBox.bind(this));
+    this.colorPickerInputBox.removeEventListener(
+      eventNames.FOCUS,
+      this._onStartEditingInputBox.bind(this)
+    );
+    this.colorPickerInputBox.removeEventListener(
+      eventNames.BLUR,
+      this._onStopEditingInputBox.bind(this)
+    );
   }
 
   /**


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements

- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

Fixed a bug that removed the object when editing the hex input of the color picker.

* AS-IS
  * ![asis](https://user-images.githubusercontent.com/76134395/102418192-dda95700-3fc2-11eb-9309-3b8c50051f01.gif)
* TO-BE
  * Object is not removed, only the input box is modified.

* Solution
  * For each input box of submenus, add focus and blur event handler to generate `inputBoxEditingStarted` and `inputBoxEditingStoped` events to determine whether the color(hex) value is being edited or not.
  * The events in the submenu are received by the ui and re-fire, and the events are received in the imageEditor to know if the input box of the color picker is being editted.

---

Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
