### PR TITLE
fix: not uncheck filter's checkbox when reset image [fix #552]

### DIFF
--- a/apps/image-editor/src/js/action.js
+++ b/apps/image-editor/src/js/action.js
@@ -75,6 +75,11 @@ export default {
         this._graphics.endHandMode();
       }
     };
+    const initFilterState = () => {
+      if (this.ui.filter) {
+        this.ui.filter.initFilterCheckBoxState();
+      }
+    };
 
     return extend(
       {
@@ -104,6 +109,7 @@ export default {
           exitCropOnAction();
           this.loadImageFromURL(this.ui.initializeImgUrl, 'resetImage').then((sizeValue) => {
             exitCropOnAction();
+            initFilterState();
             this.ui.resizeEditor({ imageSize: sizeValue });
             this.clearUndoStack();
             this._initHistory();
@@ -130,6 +136,7 @@ export default {
           this.loadImageFromFile(file)
             .then((sizeValue) => {
               exitCropOnAction();
+              initFilterState();
               this.clearUndoStack();
               this.ui.activeMenuEvent();
               this.ui.resizeEditor({ imageSize: sizeValue });

--- a/apps/image-editor/src/js/ui/filter.js
+++ b/apps/image-editor/src/js/ui/filter.js
@@ -176,6 +176,19 @@ class Filter extends Submenu {
   }
 
   /**
+   * Init all filter's checkbox to unchecked state
+   */
+  initFilterCheckBoxState() {
+    snippet.forEach(
+      this.checkedMap,
+      (filter) => {
+        filter.checked = false;
+      },
+      this
+    );
+  }
+
+  /**
    * Set filter for undo changed
    * @param {string} filterName - filter name
    * @param {Object} options - filter options


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements

- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

Fix a bug that does not uncheck the filter's check box when a reset or image is loaded after applying the filter

* AS-IS
  * ![화면-기록-2021-04-01-오후-5 07 09](https://user-images.githubusercontent.com/28647773/113263646-fe48b300-930c-11eb-8e5f-56873f9db19d.gif)
* TO-BE
  * Uncheck the filter box when resetting or loading images after applying the filter.

* Solution
  * Add logic to uncheck all filter check boxes when reset or image load
---

Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
