### PR TITLE
Cannot find module '@toast-ui/vue-image-editor' error solved.

### DIFF
--- a/apps/vue-image-editor/index.js
+++ b/apps/vue-image-editor/index.js
@@ -1,0 +1,3 @@
+import ImageEditor from './src/ImageEditor.vue';
+
+export { ImageEditor };


### PR DESCRIPTION
When we installed the module with npm, it could not find the module because there was no index.js file in the main directory.

Adding this solves the problem.