### PR TITLE
fix: Inline "px" labels for resize image feature

### DIFF
--- a/apps/image-editor/src/js/ui/template/submenu/resize.js
+++ b/apps/image-editor/src/js/ui/template/submenu/resize.js
@@ -10,11 +10,11 @@ export default ({ locale, makeSvgIcon }) => `
             <div class="tui-image-editor-range-wrap tui-image-editor-newline">
                 <label class="range">${locale.localize('Width')}&nbsp;</label>
                 <div class="tie-width-range"></div>
-                <input class="tie-width-range-value tui-image-editor-range-value" value="0" /> <label class="range">px</label>
+                <input class="tie-width-range-value tui-image-editor-range-value" value="0" /> <label>px</label>
                 <div class="tui-image-editor-partition tui-image-editor-newline"></div>
                 <label class="range">${locale.localize('Height')}</label>
                 <div class="tie-height-range"></div>
-                <input class="tie-height-range-value tui-image-editor-range-value" value="0" /> <label class="range">px</label>
+                <input class="tie-height-range-value tui-image-editor-range-value" value="0" /> <label>px</label>
             </div>
         </li>
         <li class="tui-image-editor-partition tui-image-editor-newline"></li>


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements

- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description
Hi all, this PR fixes a visual issue with labels on the resize feature while using `menuBarPosition: "left|right"`. When using either of those two modes the "px" labels are not inline and appear on a different line. Screenshots show the before/after.

Before:
![image](https://user-images.githubusercontent.com/1253062/134695152-6bcf0e90-2b54-4f77-aafd-2660d35bc47e.png)

After:
![image](https://user-images.githubusercontent.com/1253062/134695365-df5ab8d3-bd6f-4ad1-83ea-ddb150ee2572.png)

