### PR TITLE
fix: Update range component to not trigger changes immediately after typing (close #643)

### DIFF
--- a/apps/image-editor/src/js/ui/tools/range.js
+++ b/apps/image-editor/src/js/ui/tools/range.js
@@ -37,13 +37,14 @@ class Range {
     this._useDecimal = options.useDecimal;
     this._absMax = this._min * -1 + this._max;
     this.realTimeEvent = options.realTimeEvent || false;
+    this._userInputTimer = null;
 
     this.eventHandler = {
       startChangingSlide: this._startChangingSlide.bind(this),
       stopChangingSlide: this._stopChangingSlide.bind(this),
       changeSlide: this._changeSlide.bind(this),
       changeSlideFinally: this._changeSlideFinally.bind(this),
-      changeInput: this._changeValueWithInput.bind(this, false),
+      changeInput: this._changeInput.bind(this),
       changeInputFinally: this._changeValueWithInput.bind(this, true),
       changeInputWithArrow: this._changeValueWithInputKeyEvent.bind(this),
     };
@@ -172,7 +173,7 @@ class Range {
   _addInputEvent() {
     if (this.rangeInputElement) {
       this.rangeInputElement.addEventListener('keydown', this.eventHandler.changeInputWithArrow);
-      this.rangeInputElement.addEventListener('keyup', this.eventHandler.changeInput);
+      this.rangeInputElement.addEventListener('keydown', this.eventHandler.changeInput);
       this.rangeInputElement.addEventListener('blur', this.eventHandler.changeInputFinally);
     }
   }
@@ -184,7 +185,7 @@ class Range {
   _removeInputEvent() {
     if (this.rangeInputElement) {
       this.rangeInputElement.removeEventListener('keydown', this.eventHandler.changeInputWithArrow);
-      this.rangeInputElement.removeEventListener('keyup', this.eventHandler.changeInput);
+      this.rangeInputElement.removeEventListener('keydown', this.eventHandler.changeInput);
       this.rangeInputElement.removeEventListener('blur', this.eventHandler.changeInputFinally);
     }
   }
@@ -233,6 +234,29 @@ class Range {
     return value;
   }
 
+  _changeInput(e) {
+    clearTimeout(this._userInputTimer);
+
+    const keyCode = e.key.charCodeAt(0);
+    if (keyCode < 48 || keyCode > 57) {
+      e.preventDefault();
+
+      return;
+    }
+
+    this._userInputTimer = setTimeout(() => {
+      this._inputSetValue(e.target.value);
+    }, 350);
+  }
+
+  _inputSetValue(stringValue) {
+    let value = this._useDecimal ? Number(stringValue) : toInteger(stringValue);
+    value = clamp(value, this._min, this.max);
+
+    this.value = value;
+    this.fire('change', value, true);
+  }
+
   /**
    * change angle event
    * @param {boolean} isLast - Is last change
@@ -251,11 +275,7 @@ class Range {
     target.value = stringValue;
 
     if (!waitForChange) {
-      let value = this._useDecimal ? Number(stringValue) : toInteger(stringValue);
-      value = clamp(value, this._min, this.max);
-
-      this.value = value;
-      this.fire('change', value, isLast);
+      this._inputSetValue(stringValue);
     }
   }
 


### PR DESCRIPTION
…typing

<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements

- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

Hi all, in this PR I propose a change to the way the Range component handles user input. Currently, input will be processed immediately and in case it is smaller than a certain minimal value it will be replaced with the minimum value making it impossible to type widths such as "150" due to it.

The PR handles input differently by allowing the user to have a grace period of 350ms and only after that time passes is the input processed. This also addresses #643, which is the same problem experienced by another user of the library.

Looking forward to your input.