### PR TITLE
Exposing fabricjs canvas object within ImageEditor class

### DIFF
--- a/apps/image-editor/src/js/graphics.js
+++ b/apps/image-editor/src/js/graphics.js
@@ -161,6 +161,15 @@ class Graphics {
   }
 
   /**
+   * Load canvas data
+   */
+   loadCanvas(json) {
+    this._canvas.loadFromJSON(json, this.renderAll());
+
+    return this;
+  }
+
+  /**
    * Destroy canvas element
    */
   destroy() {

--- a/apps/image-editor/src/js/imageEditor.js
+++ b/apps/image-editor/src/js/imageEditor.js
@@ -1686,6 +1686,17 @@ class ImageEditor {
   }
 
   /**
+   * Load the FabricJS canvas obj to editor
+   * @param {String | Object} json - FabricJS Canvas object
+   * ref: http://fabricjs.com/docs/fabric.Canvas.html#loadFromJSON
+   * @example
+   * imageEditor.loadCanvas({canvasData});
+   */
+   loadCanvas(json) {
+    return this._graphics.loadCanvas(json);
+  }
+
+  /**
    * Get the full FabricJS canvas obj
    * @returns {Object} {{canvas}} FabricJS canvas object
    * @example


### PR DESCRIPTION
Exposing the FabricJS canvas object and the `loadFromJSON` FabricJS function via the core `imageEditor` class
http://fabricjs.com/docs/fabric.Canvas.html#loadFromJSON

Exporting Canvas example:
```
import ImageEditor from '@toast-ui/react-image-editor';

var canvasData = imageEditor.getCanvas();
console.log(canvasData);
```

After storing the whole `Canvas` object inside a variable, it can then be saved to MongoDB. In theory, you can then fetch this object from MongoDB and it can be restored using the loadFromJSON FabricJS function which is exposed via the `imageEditor` class.

Example:
```
import ImageEditor from '@toast-ui/react-image-editor';

const canvasData = someFunction.getCanvasFromMongoDB()
imageEditor.loadCanvas(canvasData);
```

FYI this is completely experimental and has not been tested. It is only for example.