### PR TITLE
fix: respect presetRatio on new cropzone

### DIFF
--- a/apps/image-editor/tests/cropper.spec.js
+++ b/apps/image-editor/tests/cropper.spec.js
@@ -184,6 +184,40 @@ describe('Cropper', () => {
         height: 20,
       });
     });
+
+    it('should restrict cropzone dimensions to presetRatio', () => {
+      const dimension = cropper._calcRectDimensionFromPoint(50, 100, 16 / 9);
+
+      expect(dimension).toEqual({
+        left: 10,
+        top: 20,
+        width: 40,
+        height: 22.5, // width / presetRatio -> 60 / 1,777777778
+      });
+    });
+
+    it('should restrict cropzone within canvas and keep presetRatio when width too large', () => {
+      const dimension = cropper._calcRectDimensionFromPoint(110, 100, 16 / 9);
+
+      expect(dimension).toEqual({
+        left: 10,
+        top: 20,
+        width: 90, // maxwidth (100) minus start (10)
+        height: 50.625, // width / presetRatio -> 90 / (16/9)
+      });
+    });
+
+    it('should restrict cropzone within canvas and keep presetRatio when height too large', () => {
+      cropper._startY = 177.5;
+      const dimension = cropper._calcRectDimensionFromPoint(100, 250, 16 / 9);
+
+      expect(dimension).toEqual({
+        left: 10,
+        top: 177.5,
+        width: 40, // height * presetRatio -> 22.5 * (16/9)
+        height: 22.5, // maxwidth (200) minus start (177.5)
+      });
+    });
   });
 
   it('should activate cropzone', () => {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

Problem (how it is now): 
- in crop mode
- choose a preset ratio (eg. 16/9)
- draw/make a new cropzone
- the aspect ratio is not restricted to the chosen preset ratio (not like when resizing the cropzone by the corners)

This PR fixes that problem. When you now draw/make a new cropzone while having selected a  preset ratio, that preset ratio is now respected.

