### PR TITLE
fix: keep shape properties form and the fabric state in sync (fix #719, #682)

### DIFF
--- a/apps/image-editor/src/js/action.js
+++ b/apps/image-editor/src/js/action.js
@@ -339,6 +339,11 @@ export default {
         changeShape: (changeShapeObject, isSilent) => {
           if (this.activeObjectId) {
             this.changeShape(this.activeObjectId, changeShapeObject, isSilent);
+          } else {
+            this.setDrawingShape(this.ui.shape.type, {
+              ...this.ui.shape.options,
+              ...changeShapeObject,
+            });
           }
         },
         setDrawingShape: (shapeType) => {
@@ -589,7 +594,7 @@ export default {
           this.ui.shape.setShapeStatus({
             strokeColor: obj.stroke,
             strokeWidth: obj.strokeWidth,
-            fillColor: obj.fill,
+            fillColor: obj.fill.color,
           });
 
           this.ui.shape.setMaxStrokeValue(Math.min(obj.width, obj.height));


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements

- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- **I didn't add tests, but happy to take suggestions for the right tests to add**
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

---
The bugs are described in the linked issues.

The fix for updating the fill color on selecting an existing object highlights something that isn't very clear in the code. The stroke color is a simple string value for the color Hex, while the fill property is actually an object with a color and a "fill type" ( I assume to support fill patterns which I know fabric has).

Properties on an object as seen in the debugger in the objectActivated() method in actions.js
```
    "fill": {
        "type": "color",
        "color": "#ff6518"
    },
    "stroke": "#03bd9e",
```
