### PR TITLE
feat: restrict zoomed image goes out of canvas

### DIFF
--- a/apps/image-editor/src/js/component/zoom.js
+++ b/apps/image-editor/src/js/component/zoom.js
@@ -576,6 +576,26 @@ class Zoom extends Component {
     const canvas = this.getCanvas();
     const { moveHand, stopHand } = this._listeners;
 
+    const canvasWidth = canvas.width;
+    const canvasHeight = canvas.height;
+
+    const vpt = canvas.viewportTransform;
+    const { zoomLevel } = this;
+
+    if (vpt[4] >= 0) {
+      vpt[4] = 0;
+    } else if (vpt[4] < canvasWidth - canvasWidth * zoomLevel) {
+      vpt[4] = canvasWidth - canvasWidth * zoomLevel;
+    }
+
+    if (vpt[5] >= 0) {
+      vpt[5] = 0;
+    } else if (vpt[5] < canvasHeight - canvasHeight * zoomLevel) {
+      vpt[5] = canvasHeight - canvasHeight * zoomLevel;
+    }
+    canvas.setViewportTransform(vpt);
+    this._fireZoomChanged(canvas, zoomLevel);
+
     canvas.off({
       'mouse:move': moveHand,
       'mouse:up': stopHand,

--- a/apps/image-editor/src/js/component/zoom.js
+++ b/apps/image-editor/src/js/component/zoom.js
@@ -582,18 +582,11 @@ class Zoom extends Component {
     const vpt = canvas.viewportTransform;
     const { zoomLevel } = this;
 
-    if (vpt[4] >= 0) {
-      vpt[4] = 0;
-    } else if (vpt[4] < canvasWidth - canvasWidth * zoomLevel) {
-      vpt[4] = canvasWidth - canvasWidth * zoomLevel;
-    }
+    vpt[4] = clamp(vpt[4], 0, canvasWidth - canvasWidth * zoomLevel);
+    vpt[5] = clamp(vpt[5], 0, canvasHeight - canvasHeight * zoomLevel);
 
-    if (vpt[5] >= 0) {
-      vpt[5] = 0;
-    } else if (vpt[5] < canvasHeight - canvasHeight * zoomLevel) {
-      vpt[5] = canvasHeight - canvasHeight * zoomLevel;
-    }
     canvas.setViewportTransform(vpt);
+
     this._fireZoomChanged(canvas, zoomLevel);
 
     canvas.off({


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements

- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

Good day!

#### problem

- image goes out of canvas and **blank space appears** when image zoomed and moved by hand mode

![ezgif com-gif-maker](https://user-images.githubusercontent.com/68575268/164611586-6ce9d760-ff45-4cb9-9489-ed0ad1b37fb8.gif)

if user download the image, blank space also comes out there, too.

<img src="https://user-images.githubusercontent.com/68575268/164611763-e851bec8-029a-4a85-9032-1c86726a8bb9.png" width="400" height="300" />

#### enhancement

- prevent the image move by **restricting hand move action**

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/68575268/164612168-6741ad0a-0933-4364-8072-d9ed2fbf188b.gif)


#### reference

- Instagram

![ezgif com-gif-maker](https://user-images.githubusercontent.com/68575268/164613669-a9d47fa3-68b6-4d9a-b50f-f655522acace.gif)


Thank you
---

Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
