### PR TITLE
fix: rotatingPointOffset (fixes #559)

### DIFF
--- a/apps/image-editor/examples/example01-includeUi.html
+++ b/apps/image-editor/examples/example01-includeUi.html
@@ -53,6 +53,9 @@
         },
         cssMaxWidth: 700,
         cssMaxHeight: 500,
+        selectionStyle: {
+          rotatingPointOffset: 70
+        },
         usageStatistics: false,
       });
       window.onresize = function () {

--- a/apps/image-editor/src/js/imageEditor.js
+++ b/apps/image-editor/src/js/imageEditor.js
@@ -245,6 +245,9 @@ class ImageEditor {
       this._attachColorPickerInputBoxEvents();
     }
     fabric.enableGLFiltering = false;
+    if (options.selectionStyle.rotatingPointOffset)
+      fabric.Object.prototype.controls.mtr.offsetY =
+        options.selectionStyle.rotatingPointOffset * -1;
   }
 
   _attachColorPickerInputBoxEvents() {


### PR DESCRIPTION
RotatingPointOffset was removed from fabric since v4.
fabric uses default controls with an extra offsetY parameter to handle this now.
They can be overwritten with custom values, so with initialization of the editor, setting the mtr control offsetY will create the desired behaviour.

Value also included in UI example