### PR TITLE
fix: Pass options prop to editor instance.

### DIFF
--- a/apps/vue-image-editor/src/ImageEditor.vue
+++ b/apps/vue-image-editor/src/ImageEditor.vue
@@ -28,7 +28,7 @@ export default {
     },
   },
   mounted() {
-    let options = editorDefaultOptions;
+    let options = this.options;
     if (this.includeUi) {
       options = Object.assign(includeUIOptions, this.options);
     }


### PR DESCRIPTION
fix: Vue wrapper instance options.

### Description
This PR fixes an issue with Vue wrapper component not setting editor options properly.
