### PR TITLE
fix: background-color property typo

### DIFF
--- a/apps/image-editor/src/css/range.styl
+++ b/apps/image-editor/src/css/range.styl
@@ -5,7 +5,7 @@
     .{prefix}-virtual-range-subbar
     .{prefix}-virtual-range-pointer
         .{prefix}-disabled
-            backbround-color: red;
+            background-color: red;
 
     .{prefix}-range
         position: relative;


### PR DESCRIPTION
fixed css property typo from `backbround-color` to `background-color`