### PR TITLE
fix: fill types

### DIFF
--- a/apps/image-editor/index.d.ts
+++ b/apps/image-editor/index.d.ts
@@ -190,9 +190,15 @@ declare namespace tuiImageEditor {
     rotatingPointOffset?: number;
   }
 
+  interface IShapeFillOption {
+    type: 'color' | 'filter'
+    filter?: Array<Record<string, number>>
+    color?: string
+  }
+
   interface IObjectProps {
     // icon, shape
-    fill: string;
+    fill: string | IShapeFillOption;
     height: number;
     id: number;
     left: number;


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
Fix for mismatch types for fill types
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements

- [ ] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

Documentations states that objects can have fill option as either string or ShapeFillOption, but it was not typed.
rel: https://nhn.github.io/tui.image-editor/latest/ShapeFillOption

---

Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
