### PR TITLE
fix: avoid creating 0-size line and shape

### DIFF
--- a/apps/image-editor/src/js/component/line.js
+++ b/apps/image-editor/src/js/component/line.js
@@ -170,7 +170,12 @@ class Line extends Component {
   _onFabricMouseUp() {
     const canvas = this.getCanvas();
 
-    this.fire(eventNames.OBJECT_ADDED, this._createLineEventObjectProperties());
+    const line = this._createLineEventObjectProperties();
+    if (line.width <= 0 && line.height <= 0) {
+      canvas.remove(this._line);
+    } else {
+      this.fire(eventNames.OBJECT_ADDED, line);
+    }
 
     this._line = null;
 

--- a/apps/image-editor/src/js/component/shape.js
+++ b/apps/image-editor/src/js/component/shape.js
@@ -40,8 +40,8 @@ const SHAPE_INIT_OPTIONS = extend(
   SHAPE_DEFAULT_OPTIONS
 );
 const DEFAULT_TYPE = 'rect';
-const DEFAULT_WIDTH = 20;
-const DEFAULT_HEIGHT = 20;
+// const DEFAULT_WIDTH = 20;
+// const DEFAULT_HEIGHT = 20;
 
 /**
  * Make fill option
@@ -480,22 +480,29 @@ export default class Shape extends Component {
    */
   _onFabricMouseUp() {
     const canvas = this.getCanvas();
-    const startPointX = this._startPoint.x;
-    const startPointY = this._startPoint.y;
+    // const startPointX = this._startPoint.x;
+    // const startPointY = this._startPoint.y;
     const shape = this._shapeObj;
 
-    if (!shape) {
-      this.add(this._type, {
-        left: startPointX,
-        top: startPointY,
-        width: DEFAULT_WIDTH,
-        height: DEFAULT_HEIGHT,
-      }).then((objectProps) => {
-        this.fire(eventNames.ADD_OBJECT, objectProps);
-      });
-    } else if (shape) {
-      resizeHelper.adjustOriginToCenter(shape);
-      this.fire(eventNames.OBJECT_ADDED, this.graphics.createObjectProperties(shape));
+    /*
+     if (!shape) {
+       this.add(this._type, {
+         left: startPointX,
+         top: startPointY,
+         width: DEFAULT_WIDTH,
+         height: DEFAULT_HEIGHT,
+       }).then((objectProps) => {
+         this.fire(eventNames.ADD_OBJECT, objectProps);
+       });
+     } else
+    */
+    if (shape) {
+      if (shape.width > 0 && shape.height > 0) {
+        resizeHelper.adjustOriginToCenter(shape);
+        this.fire(eventNames.OBJECT_ADDED, this.graphics.createObjectProperties(shape));
+      } else {
+        canvas.remove(shape);
+      }
     }
 
     canvas.off({


### PR DESCRIPTION
It's no necessary to create line/shape when just click the canvas without any movement.
The line/shape with zero width and zero height will not be able to resize when it been created.